### PR TITLE
Implement static tool framework

### DIFF
--- a/tesla/CMakeLists.txt
+++ b/tesla/CMakeLists.txt
@@ -56,4 +56,4 @@ add_subdirectory(common)
 add_subdirectory(instrumenter)
 add_subdirectory(test)
 add_subdirectory(tools)
-
+add_subdirectory(static)

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -1,0 +1,11 @@
+#include "AcquireReleasePass.h"
+
+namespace tesla {
+
+void AcquireReleasePass::run(
+    const shared_ptr<Manifest> &Ma, 
+    const shared_ptr<llvm::Module> &Mo) 
+{
+}
+
+}

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -2,10 +2,7 @@
 
 namespace tesla {
 
-void AcquireReleasePass::run(
-    const shared_ptr<Manifest> &Ma, 
-    const shared_ptr<llvm::Module> &Mo) 
-{
+void AcquireReleasePass::run(Manifest &Ma, llvm::Module &Mo) {
 }
 
 }

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -1,0 +1,15 @@
+#ifndef ACQUIRE_RELEASE_PASS_H
+#define ACQUIRE_RELEASE_PASS_H
+
+#include "ManifestPass.h"
+
+namespace tesla {
+
+class AcquireReleasePass : public ManifestPass {
+  virtual void run(const shared_ptr<Manifest> &Ma, 
+                   const shared_ptr<llvm::Module> &Mo) override;
+};
+
+}
+
+#endif

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -6,8 +6,7 @@
 namespace tesla {
 
 class AcquireReleasePass : public ManifestPass {
-  virtual void run(const shared_ptr<Manifest> &Ma, 
-                   const shared_ptr<llvm::Module> &Mo) override;
+  virtual void run(Manifest &Ma, llvm::Module &Mo) override;
 };
 
 }

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_executable(tesla-static
   static.cpp
   ManifestPass.cpp
   ManifestPassManager.cpp
+  AcquireReleasePass.cpp
 )
 
 target_link_libraries(tesla-static

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -1,7 +1,12 @@
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS tesla.proto)
 
+set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD}
+)
+
 add_llvm_executable(tesla-static
   static.cpp
+  ManifestPass.cpp
+  ManifestPassManager.cpp
 )
 
 target_link_libraries(tesla-static

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -1,0 +1,13 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS tesla.proto)
+
+add_llvm_executable(tesla-static
+  static.cpp
+)
+
+target_link_libraries(tesla-static
+  TeslaCommon
+)
+
+include_directories("${CMAKE_SOURCE_DIR}/../include")
+
+install(TARGETS tesla-static DESTINATION bin)

--- a/tesla/static/ManifestPass.cpp
+++ b/tesla/static/ManifestPass.cpp
@@ -1,0 +1,10 @@
+#include "ManifestPass.h"
+
+using std::shared_ptr;
+
+namespace tesla {
+
+ManifestPass::ManifestPass() {
+}
+
+}

--- a/tesla/static/ManifestPass.cpp
+++ b/tesla/static/ManifestPass.cpp
@@ -3,8 +3,4 @@
 using std::shared_ptr;
 
 namespace tesla {
-
-ManifestPass::ManifestPass() {
-}
-
 }

--- a/tesla/static/ManifestPass.h
+++ b/tesla/static/ManifestPass.h
@@ -1,0 +1,20 @@
+#ifndef MANIFEST_PASS_H
+#define MANIFEST_PASS_H
+
+#include "Manifest.h"
+
+#include <llvm/IR/Module.h>
+
+using std::shared_ptr;
+
+namespace tesla {
+
+class ManifestPass {
+  public:
+    ManifestPass();
+    virtual void run(const shared_ptr<Manifest> &Ma, const shared_ptr<llvm::Module> &Mo) = 0;
+};
+
+}
+
+#endif

--- a/tesla/static/ManifestPass.h
+++ b/tesla/static/ManifestPass.h
@@ -11,7 +11,6 @@ namespace tesla {
 
 class ManifestPass {
   public:
-    ManifestPass();
     virtual void run(const shared_ptr<Manifest> &Ma, const shared_ptr<llvm::Module> &Mo) = 0;
 };
 

--- a/tesla/static/ManifestPass.h
+++ b/tesla/static/ManifestPass.h
@@ -11,7 +11,7 @@ namespace tesla {
 
 class ManifestPass {
   public:
-    virtual void run(const shared_ptr<Manifest> &Ma, const shared_ptr<llvm::Module> &Mo) = 0;
+    virtual void run(Manifest &Ma, llvm::Module &Mo) = 0;
 };
 
 }

--- a/tesla/static/ManifestPassManager.cpp
+++ b/tesla/static/ManifestPassManager.cpp
@@ -1,0 +1,19 @@
+#include "ManifestPassManager.h"
+
+namespace tesla {
+
+ManifestPassManager::ManifestPassManager(const shared_ptr<tesla::Manifest> &Ma, 
+                                         const shared_ptr<llvm::Module> &Mo) :
+  Manifest(Ma), Mod(Mo) {}
+
+void ManifestPassManager::addPass(ManifestPass *pass) {
+  passes.push_back(pass);
+}
+
+void ManifestPassManager::runPasses() {
+  for(auto pass : passes) {
+    pass->run(Manifest, Mod);
+  }
+}
+
+}

--- a/tesla/static/ManifestPassManager.cpp
+++ b/tesla/static/ManifestPassManager.cpp
@@ -12,7 +12,7 @@ void ManifestPassManager::addPass(ManifestPass *pass) {
 
 void ManifestPassManager::runPasses() {
   for(auto pass : passes) {
-    pass->run(Manifest, Mod);
+    pass->run(*Manifest, *Mod);
   }
 }
 

--- a/tesla/static/ManifestPassManager.h
+++ b/tesla/static/ManifestPassManager.h
@@ -1,0 +1,27 @@
+#ifndef MANIFEST_PASS_MANAGER_H
+#define MANIFEST_PASS_MANAGER_H
+
+#include "ManifestPass.h"
+
+#include <vector>
+
+#include <llvm/IR/Module.h>
+
+using std::vector;
+
+namespace tesla {
+
+class ManifestPassManager {
+  public:
+    ManifestPassManager(const shared_ptr<Manifest> &Ma, const shared_ptr<llvm::Module> &Mo);
+    void addPass(ManifestPass *pass);
+    void runPasses();
+  private:
+    vector<ManifestPass *> passes;
+    shared_ptr<tesla::Manifest> Manifest;
+    shared_ptr<llvm::Module> Mod;
+};
+
+}
+
+#endif

--- a/tesla/static/static.cpp
+++ b/tesla/static/static.cpp
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/tesla/static/static.cpp
+++ b/tesla/static/static.cpp
@@ -1,5 +1,7 @@
 #include "Debug.h"
 #include "Manifest.h"
+#include "ManifestPassManager.h"
+#include "AcquireReleasePass.h"
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
@@ -38,6 +40,11 @@ int main(int argc, char **argv) {
     Err.print(argv[0], errs());
     return 1;
   }
+
+  tesla::ManifestPassManager PM(Manifest, Mod);
+  PM.addPass(new tesla::AcquireReleasePass);
+
+  PM.runPasses();
 
   return 0;
 }

--- a/tesla/static/static.cpp
+++ b/tesla/static/static.cpp
@@ -1,3 +1,43 @@
-int main() {
+#include "Debug.h"
+#include "Manifest.h"
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/ManagedStatic.h>
+#include <llvm/Support/PrettyStackTrace.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/SourceMgr.h>
+
+using namespace llvm;
+
+static cl::opt<std::string>
+ManifestFilename(cl::Positional, cl::desc("manifest"), cl::Required);
+
+static cl::opt<std::string>
+BitcodeFilename(cl::Positional, cl::desc("bitcode"), cl::Required);
+
+int main(int argc, char **argv) {
+  PrettyStackTraceProgram X(argc, argv);
+  llvm_shutdown_obj Y;
+  LLVMContext &Context = getGlobalContext();
+
+  cl::ParseCommandLineOptions(argc, argv, "TESLA Static Analyser\n");
+
+  SMDiagnostic Err;
+  
+  std::shared_ptr<tesla::Manifest> Manifest(tesla::Manifest::load(
+    llvm::errs(), tesla::Automaton::Deterministic, ManifestFilename));
+  if(!Manifest) {
+    tesla::panic("unable to load TESLA manifest");
+  }
+
+  std::shared_ptr<Module> Mod(ParseIRFile(BitcodeFilename, Err, Context));
+  if(Mod.get() == nullptr) {
+    Err.print(argv[0], errs());
+    return 1;
+  }
+
   return 0;
 }


### PR DESCRIPTION
This sets up the boilerplate needed for a basic static analysis tool to be included in TESLA. The workflow will be similar to that used by LLVM: passes that operate on a manifest and a linked IR file (whole program analysis for now) can be run on files by the tool.

The next step is to use this framework to actually implement some static analysis.