### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 doxygen
 .clang_complete
+*.pyc

--- a/tesla/test/Instrumentation/assertion-site.c
+++ b/tesla/test/Instrumentation/assertion-site.c
@@ -2,7 +2,7 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file %t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/bitmask.c
+++ b/tesla/test/Instrumentation/bitmask.c
@@ -3,7 +3,7 @@
  * Check instrumentation of function calls with flags combined in a bitmask.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang %cflags -emit-llvm -S -o %t.ll %s
+ * RUN: %clang %cflags -emit-llvm -S -o %t.ll %s
  * RUN: tesla instrument -S -tesla-manifest %t.tesla -o %t.instr.ll %t.ll
  * RUN: %filecheck -input-file=%t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/callee.c
+++ b/tesla/test/Instrumentation/callee.c
@@ -2,7 +2,7 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file %t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/caller.c
+++ b/tesla/test/Instrumentation/caller.c
@@ -2,7 +2,7 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file %t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/combining.c
+++ b/tesla/test/Instrumentation/combining.c
@@ -6,10 +6,10 @@
 /*
  * Commands for llvm-lit:
  * RUN: mkdir -p %t
- * RUN: clang -S -emit-llvm %cflags %s -o %t/main.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t/main.ll
  * RUN: tesla analyse %s -o %t/tesla -- %cflags
  * RUN: tesla instrument -S -tesla-manifest %t/tesla %t/main.ll -o %t/instr.ll
- * RUN: clang %ldflags %t/instr.ll -o %t/binary
+ * RUN: %clang %ldflags %t/instr.ll -o %t/binary
  * RUN: %filecheck -check-prefix=INSTR -input-file %t/instr.ll %s
  * RUN: %t/binary | tee %t/out.txt
  * RUN: %filecheck -check-prefix=TESLA -input-file %t/out.txt %s

--- a/tesla/test/Instrumentation/constant-arg.c
+++ b/tesla/test/Instrumentation/constant-arg.c
@@ -3,7 +3,7 @@
  * Ensure constant arguments to instrumented functions are properly checked.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang %cflags -emit-llvm -S -o %t.ll %s
+ * RUN: %clang %cflags -emit-llvm -S -o %t.ll %s
  * RUN: tesla instrument -S -tesla-manifest %t.tesla -o %t.instr.ll %t.ll
  * RUN: %filecheck -input-file=%t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/field-assign.c
+++ b/tesla/test/Instrumentation/field-assign.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  *
  * Commands for llvm-lit:
- * RUN: clang %cflags -c -S -emit-llvm %s -o %t.ll
+ * RUN: %clang %cflags -c -S -emit-llvm %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %p/tesla.manifest %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file=%t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/field-lookup.c
+++ b/tesla/test/Instrumentation/field-lookup.c
@@ -2,7 +2,7 @@
  * @file field-lookup.c
  * Check instrumentation using a struct field argument.
  *
- * RUN: clang %cflags% -c -emit-llvm -S %s -o %t.ll
+ * RUN: %clang %cflags% -c -emit-llvm -S %s -o %t.ll
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
  * RUN: tesla instrument -S %t.ll -tesla-manifest %t.tesla -o %t.instr.ll
  * RUN: %filecheck -input-file=%t.instr.ll %s

--- a/tesla/test/Instrumentation/free-variables.c
+++ b/tesla/test/Instrumentation/free-variables.c
@@ -6,7 +6,7 @@
  * This requires the GCC expression-of-statements extension.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file %t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/indirection.c
+++ b/tesla/test/Instrumentation/indirection.c
@@ -3,7 +3,7 @@
  * Check instrumentation of values passed or returned indirectly, via pointer.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang %cflags -emit-llvm -S -o %t.ll %s
+ * RUN: %clang %cflags -emit-llvm -S -o %t.ll %s
  * RUN: tesla instrument -S -tesla-manifest %t.tesla -o %t.instr.ll %t.ll
  * RUN: %filecheck -input-file=%t.instr.ll %s
  */

--- a/tesla/test/Instrumentation/intptr.c
+++ b/tesla/test/Instrumentation/intptr.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Instrumentation/static.c
+++ b/tesla/test/Instrumentation/static.c
@@ -2,7 +2,7 @@
 /*
  * Commands for llvm-lit:
  * RUN: mkdir -p %t
- * RUN: clang -S -emit-llvm %cflags %s -o %t/main.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t/main.ll
  * RUN: tesla analyse %s -o %t/tesla -- %cflags
  * RUN: tesla instrument -S -tesla-manifest %t/tesla %t/main.ll -o %t/instr.ll
  * RUN: %filecheck -input-file %t/instr.ll %s

--- a/tesla/test/Instrumentation/suppress-debug.c
+++ b/tesla/test/Instrumentation/suppress-debug.c
@@ -2,7 +2,7 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -suppress-debug-instrumentation -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file %t.instr.ll %s
  */

--- a/tesla/test/Integration/call.c
+++ b/tesla/test/Integration/call.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/field-assign.c
+++ b/tesla/test/Integration/field-assign.c
@@ -29,11 +29,11 @@
  * SUCH DAMAGE.
  *
  * Commands for llvm-lit:
- * RUN: clang %cflags -c -S -emit-llvm %s -o %t.ll
+ * RUN: %clang %cflags -c -S -emit-llvm %s -o %t.ll
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
  * RUN: %filecheck -input-file=%t.instr.ll %s
- * RUN: clang -g %ldflags %t.instr.ll -o %t
+ * RUN: %clang -g %ldflags %t.instr.ll -o %t
  * RUN: %t
  */
 

--- a/tesla/test/Integration/free-variables-mismatch.c
+++ b/tesla/test/Integration/free-variables-mismatch.c
@@ -4,9 +4,9 @@
  * actually bind events with the same value.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t > %t.out 2> %t.out || true
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/free-variables.c
+++ b/tesla/test/Integration/free-variables.c
@@ -6,9 +6,9 @@
  * This requires the GCC expression-of-statements extension.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t > %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/hold-missing.c
+++ b/tesla/test/Integration/hold-missing.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t > %t.out 2>%t.err || true
  * RUN: %filecheck -input-file %t.out %s
  * RUN: %filecheck -check-prefix=ERR -input-file %t.err %s

--- a/tesla/test/Integration/hold.c
+++ b/tesla/test/Integration/hold.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/ignored.c
+++ b/tesla/test/Integration/ignored.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/indirection.c
+++ b/tesla/test/Integration/indirection.c
@@ -3,9 +3,9 @@
  * Check instrumentation of values passed or returned indirectly, via pointer.
  *
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang %cflags -emit-llvm -S -o %t.ll %s
+ * RUN: %clang %cflags -emit-llvm -S -o %t.ll %s
  * RUN: tesla instrument -S -tesla-manifest %t.tesla -o %t.instr.ll %t.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file=%t.out %s
  */

--- a/tesla/test/Integration/release-missing.c
+++ b/tesla/test/Integration/release-missing.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t 2>%t.err | tee %t.out || true
  * RUN: %filecheck -input-file %t.out %s
  * RUN: %filecheck -check-prefix=ERR -input-file %t.err %s

--- a/tesla/test/Integration/release.c
+++ b/tesla/test/Integration/release.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/static.c
+++ b/tesla/test/Integration/static.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Integration/threading.c
+++ b/tesla/test/Integration/threading.c
@@ -2,9 +2,9 @@
 /*
  * Commands for llvm-lit:
  * RUN: tesla analyse %s -o %t.tesla -- %cflags -D TESLA
- * RUN: clang -S -emit-llvm %cflags %s -o %t.ll
+ * RUN: %clang -S -emit-llvm %cflags %s -o %t.ll
  * RUN: tesla instrument -S -tesla-manifest %t.tesla %t.ll -o %t.instr.ll
- * RUN: clang %ldflags %t.instr.ll -o %t
+ * RUN: %clang %ldflags %t.instr.ll -o %t
  * RUN: %t | tee %t.out
  * RUN: %filecheck -input-file %t.out %s
  */

--- a/tesla/test/Parsing/free-variables.c
+++ b/tesla/test/Parsing/free-variables.c
@@ -6,7 +6,7 @@
  * This requires the GCC expression-of-statements extension.
  *
  * RUN: tesla analyse -S %s -o %t -- %cflags
- * RUN: FileCheck -input-file=%t %s
+ * RUN: %filecheck -input-file=%t %s
  */
 
 #include <tesla-macros.h>


### PR DESCRIPTION
This sorts out some problems with the test suite - in a lot of places, `RUN: clang ...` was being used instead of `RUN: %clang ...`, and so the `llvm-lit` config was ignored. These locations have been found and fixed.