### PR TITLE
Fix parser bug for struct fields

### DIFF
--- a/tesla/analyser/Parser.h
+++ b/tesla/analyser/Parser.h
@@ -141,9 +141,11 @@ private:
    * passed by value into their constituent fields.
    */
   bool ParseArg(ArgFactory, const clang::Expr*,
-                Parser::Flags, bool DoNotRegister = false);
+                Parser::Flags, bool DoNotRegister = false,
+                bool justField = false);
   bool ParseArg(ArgFactory, const clang::ValueDecl*, bool AllowAny,
-                Parser::Flags, bool DoNotRegister = false);
+                Parser::Flags, bool DoNotRegister = false,
+                bool justField = false);
 
   bool ParseStructField(StructField*, const clang::MemberExpr*, Flags,
                         bool DoNotRegisterBase = false);


### PR DESCRIPTION
In theory this should fix the parser bug where structure fields are
named incorrectly when passed by value.

The fix is to add an extra parameter to ParseArg that indicates when we
are only parsing a struct field. The only place this is set to true is
in ParseStructField. Having the flag set means that the Decl version of
ParseArg will skip the part of the code that splits a structure into its
constituent parts (which we only want to to if passing a whole structure
rather than just a single field).

I think that the struct_params test covers the alternative path (i.e.
actually passing a struct by value) to make sure this change doesn't
break that behaviour.