### PR TITLE
Acquire-Release pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,10 @@ add_subdirectory(include)
 add_subdirectory(libtesla)
 add_subdirectory(tesla)
 add_subdirectory(scripts)
-add_subdirectory(experiments)
+
+if(BUILD_EXPERIMENTS)
+  add_subdirectory(experiments)
+endif()
 
 # A top-level 'check' target to drive all tests of TESLA subdirectories.
 add_custom_target(check DEPENDS libtesla-test tesla-test run-demos)

--- a/cmake/Tesla.cmake
+++ b/cmake/Tesla.cmake
@@ -1,6 +1,6 @@
 find_package(Threads)
 
-function(add_tesla_executable C_SOURCES EXE_NAME)
+function(add_tesla_executable C_SOURCES EXE_NAME STATIC)
   set(TESLA_LINK "-L/home/test/tesla_install/lib" "-ltesla")
 
   set(TESLA_INCLUDE "-I/home/test/tesla_install/include")
@@ -63,6 +63,17 @@ function(add_tesla_executable C_SOURCES EXE_NAME)
   add_custom_target(${EXE_NAME}-manifest
     ALL DEPENDS ${EXE_NAME}_tesla.manifest
   )
+
+  if(STATIC)
+    add_custom_command(
+      OUTPUT ${EXE_NAME}.static.manifest
+      COMMAND tesla static ${EXE_NAME}.manifest ${EXE_NAME}.bc -o ${EXE_NAME}.static.manifest
+      DEPENDS ${EXE_NAME}.manifest ${EXE_NAME}.bc
+    )
+    add_custom_target(${EXE_NAME}-static-manifest
+      ALL_DEPENDS ${EXE_NAME}.static.manifest
+    )
+  endif()
 
   set(INSTR_FILE ${EXE_NAME}.instr.bc)
   add_custom_command(

--- a/cmake/Tesla.cmake
+++ b/cmake/Tesla.cmake
@@ -48,20 +48,20 @@ function(add_tesla_executable C_SOURCES EXE_NAME STATIC)
 
   add_custom_command(
     OUTPUT ${EXE_NAME}.instr.bc
-    COMMAND tesla instrument -tesla-manifest ${EXE_NAME}_tesla.manifest ${EXE_NAME}.bc -o ${EXE_NAME}.instr.bc
-    DEPENDS ${EXE_NAME}.bc ${EXE_NAME}_tesla.manifest
+    COMMAND tesla instrument -tesla-manifest ${EXE_NAME}.manifest ${EXE_NAME}.bc -o ${EXE_NAME}.instr.bc
+    DEPENDS ${EXE_NAME}.bc ${EXE_NAME}.manifest
   )
   add_custom_target(${EXE_NAME}_instr
     ALL DEPENDS ${EXE_NAME}.instr.bc
   )
 
   add_custom_command(
-    OUTPUT ${EXE_NAME}_tesla.manifest
-    COMMAND tesla cat ${TESLA_FILES} -o ${EXE_NAME}_tesla.manifest
+    OUTPUT ${EXE_NAME}.manifest
+    COMMAND tesla cat ${TESLA_FILES} -o ${EXE_NAME}.manifest
     DEPENDS ${TESLA_FILES}
   )
   add_custom_target(${EXE_NAME}-manifest
-    ALL DEPENDS ${EXE_NAME}_tesla.manifest
+    ALL DEPENDS ${EXE_NAME}.manifest
   )
 
   if(STATIC)

--- a/cmake/Tesla.cmake
+++ b/cmake/Tesla.cmake
@@ -64,7 +64,7 @@ function(add_tesla_executable C_SOURCES EXE_NAME STATIC)
     ALL DEPENDS ${EXE_NAME}.manifest
   )
 
-  if(STATIC)
+  if(STATIC AND CMAKE_USE_STATIC)
     add_custom_command(
       OUTPUT ${EXE_NAME}.static.manifest
       COMMAND tesla static ${EXE_NAME}.manifest ${EXE_NAME}.bc -o ${EXE_NAME}.static.manifest

--- a/cmake/Tesla.cmake
+++ b/cmake/Tesla.cmake
@@ -73,6 +73,25 @@ function(add_tesla_executable C_SOURCES EXE_NAME STATIC)
     add_custom_target(${EXE_NAME}-static-manifest
       ALL_DEPENDS ${EXE_NAME}.static.manifest
     )
+    
+    add_custom_command(
+      OUTPUT ${EXE_NAME}.static.instr.bc
+      COMMAND tesla instrument -tesla-manifest ${EXE_NAME}.static.manifest ${EXE_NAME}.bc -o ${EXE_NAME}.static.instr.bc
+      DEPENDS ${EXE_NAME}.bc ${EXE_NAME}.static.manifest
+    )
+    add_custom_target(${EXE_NAME}_static-instr
+      ALL DEPENDS ${EXE_NAME}.static.instr.bc
+    )
+
+    set(INSTR_FILE ${EXE_NAME}.static.instr.bc)
+    add_custom_command(
+      OUTPUT ${EXE_NAME}_static
+      COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${CMAKE_THREAD_LIBS_INIT} ${TESLA_LINK} ${INSTR_FILE} -o ${EXE_NAME}_static
+      DEPENDS ${INSTR_FILE}
+    )
+    add_custom_target(${EXE_NAME}-static-tesla-all
+      ALL DEPENDS ${EXE_NAME}_static
+    )
   endif()
 
   set(INSTR_FILE ${EXE_NAME}.instr.bc)

--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(locks)
+add_subdirectory(indirect)

--- a/experiments/indirect/CMakeLists.txt
+++ b/experiments/indirect/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(Indirect)
+
+add_tesla_executable(main.c indirect False)

--- a/experiments/indirect/main.c
+++ b/experiments/indirect/main.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <tesla.h>
+#include <tesla-macros.h>
+
+struct test_struct {
+  int field __attribute__((annotate("field:test_struct.field")));
+};
+
+void init(struct test_struct **s) {
+  (*s)->field = 0;
+}
+
+void end(struct test_struct **s) {
+  (*s)->field = -1;
+}
+
+int main(void) {
+  struct test_struct *st = malloc(sizeof(*st));
+
+  TESLA_WITHIN(main, eventually(
+    TSEQUENCE(
+      call(init(&st)),
+      call(end(&st))
+    )
+  ));
+
+  init(&st);
+  end(&st);
+  
+  return 0;
+}

--- a/experiments/locks/CMakeLists.txt
+++ b/experiments/locks/CMakeLists.txt
@@ -8,7 +8,7 @@ set(MAIN_C_SOURCES
   lock.c
 )
 
-add_tesla_executable("${MAIN_C_SOURCES}" "${MAIN_EXE_NAME}")
+add_tesla_executable("${MAIN_C_SOURCES}" "${MAIN_EXE_NAME}" TRUE)
 
 function(example name)
   set(SRC
@@ -16,7 +16,7 @@ function(example name)
     lock.c
     mock.c
   )
-  add_tesla_executable("${SRC}" ${name})
+  add_tesla_executable("${SRC}" ${name} TRUE)
 endfunction()
 
 example(basic)

--- a/tesla/common/tesla.proto
+++ b/tesla/common/tesla.proto
@@ -58,6 +58,9 @@ message Usage {
 
   /** Where the automataon ends: a bound, a place for cleanup. */
   optional Expression end = 3;
+
+  /** Should this usage be instrumented or ignored (based on static analysis)? **/
+  optional bool deleted = 4;
 }
 
 

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -16,9 +16,7 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
 
   auto locs = ReferenceLocations(Man);
   for(auto root : Man.RootAutomata()) {
-    if(!UsesAcqRel(root, locs)) {
-      copyUsage(root, File);
-    }
+    copyUsage(root, File);
   }
 
   auto unique = unique_ptr<ManifestFile>(File);

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -10,10 +10,20 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
   auto File = new ManifestFile();
 
   copyDefinitions(Man, File);
-  auto unique = unique_ptr<ManifestFile>(File);
 
+  for(auto root : Man.RootAutomata()) {
+    if(!UsesAcqRel(root)) {
+      copyUsage(root, File);
+    }
+  }
+
+  auto unique = unique_ptr<ManifestFile>(File);
   return unique_ptr<Manifest>(
       Manifest::construct(llvm::errs(), Automaton::Deterministic, std::move(unique)));
+}
+
+bool AcquireReleasePass::UsesAcqRel(const Usage *usage) {
+  return false;
 }
 
 const std::string AcquireReleasePass::PassName() const {

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -16,16 +16,6 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
       Manifest::construct(llvm::errs(), Automaton::Deterministic, std::move(unique)));
 }
 
-bool AcquireReleasePass::UsesAcqRel(Manifest &Man) {
-  for(auto entry : Man.AllAutomata()) {
-    if(entry.first.name() == AutomatonName()) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 const std::string AcquireReleasePass::PassName() const {
   return "AcquireRelease";
 }

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -39,7 +39,15 @@ bool AcquireReleasePass::ReferencesAcqRel(const AutomatonDescription *aut) {
 }
 
 set<const Location> AcquireReleasePass::ReferenceLocations(Manifest &Man) {
-  return set<const Location>();
+  auto ret = set<const Location>();
+
+  for(auto entry : Man.AllAutomata()) {
+    if(ReferencesAcqRel(entry.second)) {
+      ret.insert(entry.first.location());
+    }
+  }
+
+  return ret;
 }
 
 const std::string AcquireReleasePass::PassName() const {

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -47,6 +47,22 @@ bool AcquireReleasePass::ReferencesAcqRel(const AutomatonDescription *aut) {
     tesla::panic("Expression has type SEQUENCE but no sequence data");
   }
 
+  auto seq = expr.sequence().expression();
+  for(auto it = seq.begin(); it != seq.end(); it++) {
+    if(it->type() == Expression_Type_NULL_EXPR) {
+      continue;
+    }
+
+    if(it->type() == Expression_Type_ASSERTION_SITE) {
+      it++;
+      if(it != seq.end() && it->type() == Expression_Type_SUB_AUTOMATON) {
+        if(it->subautomaton().name() == AutomatonName()) {
+          return true;
+        }
+      }
+    }
+  }
+
   return false;
 }
 

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -1,5 +1,7 @@
 #include "AcquireReleasePass.h"
 
+#include "Debug.h"
+
 #include <llvm/Support/raw_ostream.h>
 
 using std::unique_ptr;
@@ -35,6 +37,16 @@ bool AcquireReleasePass::UsesAcqRel(const Usage *usage, set<const Location> &loc
 }
 
 bool AcquireReleasePass::ReferencesAcqRel(const AutomatonDescription *aut) {
+  auto expr = aut->expression();
+
+  if(expr.type() != Expression_Type_SEQUENCE) {
+    return false;
+  }
+
+  if(!expr.has_sequence()) {
+    tesla::panic("Expression has type SEQUENCE but no sequence data");
+  }
+
   return false;
 }
 

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -12,7 +12,6 @@ class AcquireReleasePass : public ManifestPass {
     virtual unique_ptr<Manifest> run(Manifest &Ma, llvm::Module &Mo) override;
     virtual const std::string PassName() const override;
   private:
-    static bool UsesAcqRel(Manifest &Ma);
     static const std::string AutomatonName();
 };
 

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -13,6 +13,7 @@ class AcquireReleasePass : public ManifestPass {
     virtual const std::string PassName() const override;
   private:
     static const std::string AutomatonName();
+    static bool UsesAcqRel(const Usage *usage);
 };
 
 }

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -4,6 +4,7 @@
 #include "ManifestPass.h"
 
 using std::unique_ptr;
+using std::set;
 
 namespace tesla {
 
@@ -13,7 +14,9 @@ class AcquireReleasePass : public ManifestPass {
     virtual const std::string PassName() const override;
   private:
     static const std::string AutomatonName();
-    static bool UsesAcqRel(const Usage *usage);
+    static bool UsesAcqRel(const Usage *usage, set<const Location> &locs);
+    static bool ReferencesAcqRel(const AutomatonDescription *aut);
+    static set<const Location> ReferenceLocations(Manifest &Man);
 };
 
 }

--- a/tesla/static/ManifestPass.cpp
+++ b/tesla/static/ManifestPass.cpp
@@ -22,6 +22,10 @@ const string ManifestPass::PrefixMessage(string pre, string message) const {
   return ss.str();
 }
 
+void ManifestPass::copyUsage(const Usage *usage, ManifestFile *file) const {
+  *file->add_root() = *usage;
+}
+
 void ManifestPass::copyDefinitions(Manifest &Ma, ManifestFile *file) const {
   for(auto entry : Ma.AllAutomata()) {
     *file->add_automaton() = *entry.second;

--- a/tesla/static/ManifestPass.h
+++ b/tesla/static/ManifestPass.h
@@ -17,6 +17,7 @@ class ManifestPass {
     const std::string Debug(std::string message) const;
   protected:
     void copyDefinitions(Manifest &Ma, ManifestFile *file) const;
+    void copyUsage(const Usage *usage, ManifestFile *file) const;
   private:
     const std::string PrefixMessage(std::string prefix, std::string message) const;
 };


### PR DESCRIPTION
This PR sets up some of the groundwork for a manifest pass that can check for acquire-release usage and analyse it statically. 

Currently, the only change made is that when the pass is run, it will mark any usage that includes a reference to `acq_rel` as deleted. This is currently a no-op, as the instrumenter does not know about the deletion marker.

Next steps are to actually perform the analysis to properly determine deletion validity, as well as to modify the instrumenter to not instrument usages marked as deleted.