### PR TITLE
Don't instrument deleted usages

### DIFF
--- a/tesla/instrumenter/Callee.cpp
+++ b/tesla/instrumenter/Callee.cpp
@@ -486,6 +486,10 @@ bool FnCalleeInstrumenter::runOnModule(Module &Mod) {
   }
 
   for (auto i : M.RootAutomata()) {
+    if(i->deleted()) {
+      continue;
+    }
+
     auto& A = *M.FindAutomaton(i->identifier());
     for (auto EquivClass : A) {
       assert(!EquivClass.empty());

--- a/tesla/instrumenter/Caller.cpp
+++ b/tesla/instrumenter/Caller.cpp
@@ -106,6 +106,10 @@ bool FnCallerInstrumenter::doInitialization(Module &Mod) {
 
 
   for (auto i : M.RootAutomata()) {
+    if(i->deleted()) {
+      continue;
+    }
+
     auto& A = *M.FindAutomaton(i->identifier());
     for (auto EquivClass : A) {
       assert(!EquivClass.empty());

--- a/tesla/instrumenter/FieldReference.cpp
+++ b/tesla/instrumenter/FieldReference.cpp
@@ -99,8 +99,11 @@ bool FieldReferenceInstrumenter::runOnModule(Module &Mod) {
   //
   // First, find all struct fields that we want to instrument.
   //
-  for (auto *Root : M.RootAutomata())
-    BuildInstrumentation(*M.FindAutomaton(Root->identifier()));
+  for (auto *Root : M.RootAutomata()) {
+    if(!Root->deleted()) {
+      BuildInstrumentation(*M.FindAutomaton(Root->identifier()));
+    }
+  }
 
   //
   // Then, iterate through all uses of the LLVM pointer annotation and look


### PR DESCRIPTION
This updates all the instrumentation passes such that they will ignore
instrumentation related to a usage marked as deleted.