### PR TITLE
Fix cmake install breaking by removing Project

### DIFF
--- a/experiments/indirect/CMakeLists.txt
+++ b/experiments/indirect/CMakeLists.txt
@@ -1,3 +1,1 @@
-project(Indirect)
-
 add_tesla_executable(main.c indirect False)

--- a/experiments/locks/CMakeLists.txt
+++ b/experiments/locks/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.6.2)
 
-project(Locks)
-
 set(MAIN_EXE_NAME locks)
 set(MAIN_C_SOURCES 
   main.c


### PR DESCRIPTION
I had mistakenly added Project definitions to my experiments - these should be removed as they cause `ninja install` to break.