### PR TITLE
LLVM Pass Boilerplate

### DIFF
--- a/tesla/common/Arguments.cpp
+++ b/tesla/common/Arguments.cpp
@@ -1,0 +1,110 @@
+#include "Arguments.h"
+
+#include "Automaton.h"
+#include "Debug.h"
+
+using namespace llvm;
+
+using std::string;
+using std::vector;
+
+vector<Value*> tesla::CollectArgs(
+    Instruction *Before, const Automaton& A,
+    Module& Mod, IRBuilder<>& Builder) {
+
+  // Find named values to be passed to instrumentation.
+  std::map<string,Value*> ValuesInScope;
+  for (auto G = Mod.global_begin(); G != Mod.global_end(); G++)
+    ValuesInScope[G->getName()] = G;
+
+  auto *Fn = Before->getParent()->getParent();
+  for (auto& Arg : Fn->getArgumentList())
+    ValuesInScope[Arg.getName()] = &Arg;
+
+  auto& EntryBlock(*Fn->begin());
+  for (auto& I : EntryBlock) {
+    auto *Inst = dyn_cast<AllocaInst>(&I);
+    if (!Inst)
+      break;
+
+    ValuesInScope[Inst->getName()] = Builder.CreateLoad(Inst);
+  }
+
+  int ArgSize = 0;
+  for (auto& Arg : A.getAssertion().argument())
+    if (!Arg.free())
+      ArgSize = std::max(ArgSize + 1, Arg.index());
+
+  vector<Value*> Args(ArgSize, NULL);
+
+  for (auto& Arg : A.getAssertion().argument()) {
+    if (Arg.free())
+      continue;
+
+    string Name(BaseName(Arg));
+
+    if (ValuesInScope.find(Name) == ValuesInScope.end()) {
+      string s;
+      raw_string_ostream Out(s);
+
+      for (auto v : ValuesInScope) {
+        Out << "  \"" << v.first << "\": ";
+        v.second->getType()->print(Out);
+        Out << "\n";
+      }
+
+      panic("assertion references non-existent variable '" + BaseName(Arg)
+         + "'; was it defined under '#ifdef TESLA'?\n\n"
+           "Variables in scope are:\n" + Out.str());
+    }
+
+    Args[Arg.index()] =
+      GetArgumentValue(ValuesInScope[Name], Arg, Builder, true);
+  }
+
+  return Args;
+}
+
+Value* tesla::GetArgumentValue(Value* Param, const Argument& ArgDescrip,
+                               IRBuilder<>& Builder, bool AtAssertionSite) {
+
+  switch (ArgDescrip.type()) {
+  case Argument::Constant:
+  case Argument::Any:
+  case Argument::Variable:
+    return Param;
+
+  case Argument::Indirect:
+    // At the assertion site, we don't do the indirection thing: we are
+    // referring to local values.
+    if (AtAssertionSite)
+      return Param;
+
+    Param = Builder.CreateLoad(Param);
+    return GetArgumentValue(Param, ArgDescrip.indirection(), Builder);
+
+  case Argument::Field: {
+    // We only need to do the indirect lookup via struct fields at the
+    // assertion site; otherwise, we just care about local values.
+    if (!AtAssertionSite)
+      return Param;
+
+    const StructField& Field = ArgDescrip.field();
+    const Argument& BaseArg = Field.base();
+    auto *Base = GetArgumentValue(Param, BaseArg, Builder, AtAssertionSite);
+
+    string Name = (
+      (Base->hasName()
+        ? Base->getName()
+        : StringRef(BaseName(BaseArg))
+      )
+      + "." + Field.name()
+    ).str();
+
+    Param = Builder.CreateConstInBoundsGEP2_32(Base, 0, Field.index());
+    Param = Builder.CreateLoad(Param, Name);
+
+    return Param;
+  }
+  }
+}

--- a/tesla/common/Arguments.h
+++ b/tesla/common/Arguments.h
@@ -1,0 +1,37 @@
+/*! @file Arguments.h Helpers for collecting assertion arguments */
+
+#ifndef TESLA_ARGUMENTS_H
+#define TESLA_ARGUMENTS_H
+
+#include "tesla.pb.h"
+
+#include <libtesla.h>
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <vector>
+
+namespace llvm {
+  class Instruction;
+  class Module;
+  class Value;
+}
+
+namespace tesla {
+
+class Automaton;
+
+//!
+std::vector<llvm::Value*> CollectArgs(llvm::Instruction *, const Automaton&,
+                                      llvm::Module&, llvm::IRBuilder<>&);
+
+//! Poke through indirection, struct fields, etc.
+llvm::Value* GetArgumentValue(llvm::Value* Param, const Argument& ArgDescrip,
+                              llvm::IRBuilder<>& Builder,
+                              bool AtAssertionSite = false);
+
+}
+
+#endif

--- a/tesla/common/CMakeLists.txt
+++ b/tesla/common/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(TeslaProto ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(TeslaProto ${PROTOBUF_LIBRARY})
 
 add_library(TeslaCommon
+  Arguments.cpp
   Automaton.cpp
   Debug.cpp
   Manifest.cpp

--- a/tesla/instrumenter/Instrumentation.h
+++ b/tesla/instrumenter/Instrumentation.h
@@ -113,12 +113,6 @@ llvm::Value* ConstructKey(llvm::IRBuilder<>&, llvm::Module&,
 //! Declare a reference to an external @ref tesla_automaton.
 llvm::Constant* ExternAutomatonDescrip(const Automaton*, llvm::Module&);
 
-
-//! Poke through indirection, struct fields, etc.
-llvm::Value* GetArgumentValue(llvm::Value* Param, const Argument& ArgDescrip,
-                              llvm::IRBuilder<>& Builder,
-                              bool AtAssertionSite = false);
-
 //! Find (or create) one function-event instrumentation function.
 llvm::Function* FunctionInstrumentation(llvm::Module&, const llvm::Function&,
                                         FunctionEvent::Direction,

--- a/tesla/instrumenter/TranslationFn.cpp
+++ b/tesla/instrumenter/TranslationFn.cpp
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+#include "Arguments.h"
 #include "Automaton.h"
 #include "EventTranslator.h"
 #include "Instrumentation.h"

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -1,0 +1,17 @@
+#include "AcquireReleaseCheck.h"
+
+AcquireReleaseCheck::AcquireReleaseCheck() : ModulePass(ID) {
+}
+
+void AcquireReleaseCheck::getAnalysisUsage(AnalysisUsage &AU) const {
+}
+
+bool AcquireReleaseCheck::runOnModule(Module &M) {
+  errs() << "Running AcqRel check on a module\n";
+  return true;
+}
+  
+void AcquireReleaseCheck::print(raw_ostream &OS, const Module *m) const {
+}
+
+char AcquireReleaseCheck::ID = 0;

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -1,7 +1,9 @@
 #include "AcquireReleaseCheck.h"
 
-AcquireReleaseCheck::AcquireReleaseCheck() : ModulePass(ID) {
-}
+AcquireReleaseCheck::AcquireReleaseCheck(string bound) : 
+  ModulePass(ID), 
+  correctUsage(false),
+  boundName(bound) {}
 
 void AcquireReleaseCheck::getAnalysisUsage(AnalysisUsage &AU) const {
 }
@@ -11,6 +13,7 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
 }
   
 void AcquireReleaseCheck::print(raw_ostream &OS, const Module *m) const {
+  OS << "[AcqRel] correct usage: " << correctUsage << '\n';
 }
 
 char AcquireReleaseCheck::ID = 0;

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -7,7 +7,6 @@ void AcquireReleaseCheck::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 bool AcquireReleaseCheck::runOnModule(Module &M) {
-  errs() << "Running AcqRel check on a module\n";
   return true;
 }
   

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -1,0 +1,19 @@
+#ifndef ACQ_REL_MOD_PASS_H
+#define ACQ_REL_MOD_PASS_H
+
+#include <llvm/Pass.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
+
+using namespace llvm;
+
+class AcquireReleaseCheck : public ModulePass {
+  AcquireReleaseCheck();
+  virtual bool runOnModule(Module &M);
+  virtual void getAnalysisUsage(AnalysisUsage &AU) const;
+  void print(raw_ostream &OS, const Module *m = 0) const;
+
+  static char ID;
+};
+
+#endif

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -5,15 +5,23 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
 
+#include <string>
+
+using std::string;
 using namespace llvm;
 
 struct AcquireReleaseCheck : public ModulePass {
-  AcquireReleaseCheck();
+  AcquireReleaseCheck(string bound);
+  
+  bool CorrectUsage() { return correctUsage; }
+
   virtual bool runOnModule(Module &M);
   virtual void getAnalysisUsage(AnalysisUsage &AU) const;
   void print(raw_ostream &OS, const Module *m = 0) const;
-
   static char ID;
+private:
+  bool correctUsage;
+  string boundName;
 };
 
 #endif

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -7,7 +7,7 @@
 
 using namespace llvm;
 
-class AcquireReleaseCheck : public ModulePass {
+struct AcquireReleaseCheck : public ModulePass {
   AcquireReleaseCheck();
   virtual bool runOnModule(Module &M);
   virtual void getAnalysisUsage(AnalysisUsage &AU) const;

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -71,6 +71,14 @@ bool AcquireReleasePass::HasSimpleBounds(Usage *usage) {
     usage->end().function().function().name();
 }
 
+/**
+ * If we know that the usage has simple bounds (as described above), this
+ * function can be used to get the name of that function.
+ */
+std::string AcquireReleasePass::SimpleBoundFunction(Usage *usage) {
+  return usage->beginning().function().function().name();
+}
+
 bool AcquireReleasePass::UsesAcqRel(const Usage *usage, set<const Location> &locs) {
   if(usage->identifier().has_location()) {
     if(locs.find(usage->identifier().location()) != locs.end()) {

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -1,7 +1,9 @@
 #include "AcquireReleasePass.h"
 
+#include "AcquireReleaseCheck.h"
 #include "Debug.h"
 
+#include <llvm/PassManager.h>
 #include <llvm/Support/raw_ostream.h>
 
 using std::unique_ptr;
@@ -42,6 +44,10 @@ bool AcquireReleasePass::ShouldDelete(Usage *usage, llvm::Module &Mod) {
   if(!HasSimpleBounds(usage)) {
     return false;
   }
+
+  PassManager passes;
+  passes.add(new AcquireReleaseCheck);
+  passes.run(Mod);
 
   return false;
 }

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -46,10 +46,11 @@ bool AcquireReleasePass::ShouldDelete(Usage *usage, llvm::Module &Mod) {
   }
 
   PassManager passes;
-  passes.add(new AcquireReleaseCheck);
+  auto check = new AcquireReleaseCheck(SimpleBoundFunction(usage));
+  passes.add(check);
   passes.run(Mod);
 
-  return false;
+  return check->CorrectUsage();
 }
 
 /**

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -20,8 +20,7 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
     newRoot->CopyFrom(*root);
 
     if(UsesAcqRel(newRoot, locs)) {
-      newRoot->CopyFrom(*root);
-      newRoot->set_deleted(true);
+      newRoot->set_deleted(ShouldDelete(newRoot, Mod));
     }
     
     copyUsage(newRoot, File);
@@ -30,6 +29,10 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
   auto unique = unique_ptr<ManifestFile>(File);
   return unique_ptr<Manifest>(
       Manifest::construct(llvm::errs(), Automaton::Deterministic, std::move(unique)));
+}
+
+bool AcquireReleasePass::ShouldDelete(Usage *usage, llvm::Module &Mod) {
+  return false;
 }
 
 bool AcquireReleasePass::UsesAcqRel(const Usage *usage, set<const Location> &locs) {

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -17,6 +17,7 @@ class AcquireReleasePass : public ManifestPass {
     static bool UsesAcqRel(const Usage *usage, set<const Location> &locs);
     static bool ReferencesAcqRel(const AutomatonDescription *aut);
     static set<const Location> ReferenceLocations(Manifest &Man);
+    bool ShouldDelete(Usage *usage, llvm::Module &Mod);
 };
 
 }

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -19,6 +19,7 @@ class AcquireReleasePass : public ManifestPass {
     static set<const Location> ReferenceLocations(Manifest &Man);
     static bool ShouldDelete(Usage *usage, llvm::Module &Mod);
     static bool HasSimpleBounds(Usage *usage);
+    static std::string SimpleBoundFunction(Usage *usage);
 };
 
 }

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -17,7 +17,8 @@ class AcquireReleasePass : public ManifestPass {
     static bool UsesAcqRel(const Usage *usage, set<const Location> &locs);
     static bool ReferencesAcqRel(const AutomatonDescription *aut);
     static set<const Location> ReferenceLocations(Manifest &Man);
-    bool ShouldDelete(Usage *usage, llvm::Module &Mod);
+    static bool ShouldDelete(Usage *usage, llvm::Module &Mod);
+    static bool HasSimpleBounds(Usage *usage);
 };
 
 }

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_executable(tesla-static
   ManifestPass.cpp
   ManifestPassManager.cpp
   AcquireReleasePass.cpp
+  AcquireReleaseCheck.cpp
 )
 
 target_link_libraries(tesla-static


### PR DESCRIPTION
This PR sets up the boilerplate needed to run an LLVM pass on a module as part of the static analysis tool. In theory, the next step on this is to actually implement the LLVM IR analysis needed to check lock usage.