### PR TITLE
First Static Analysis

### DIFF
--- a/tesla/common/Arguments.cpp
+++ b/tesla/common/Arguments.cpp
@@ -11,7 +11,7 @@ using std::string;
 using std::vector;
 
 vector<Value*> tesla::CollectArgs(
-    Instruction *Before, vector<Argument> args,
+    Instruction *Before, vector<tesla::Argument> args,
     Module& Mod, IRBuilder<>& Builder) {
   // Find named values to be passed to instrumentation.
   std::map<string,Value*> ValuesInScope;

--- a/tesla/common/Arguments.cpp
+++ b/tesla/common/Arguments.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "Arguments.h"
 
 #include "Automaton.h"
@@ -9,9 +11,8 @@ using std::string;
 using std::vector;
 
 vector<Value*> tesla::CollectArgs(
-    Instruction *Before, const Automaton& A,
+    Instruction *Before, vector<Argument> args,
     Module& Mod, IRBuilder<>& Builder) {
-
   // Find named values to be passed to instrumentation.
   std::map<string,Value*> ValuesInScope;
   for (auto G = Mod.global_begin(); G != Mod.global_end(); G++)
@@ -31,13 +32,13 @@ vector<Value*> tesla::CollectArgs(
   }
 
   int ArgSize = 0;
-  for (auto& Arg : A.getAssertion().argument())
+  for (auto& Arg : args)
     if (!Arg.free())
       ArgSize = std::max(ArgSize + 1, Arg.index());
 
   vector<Value*> Args(ArgSize, NULL);
 
-  for (auto& Arg : A.getAssertion().argument()) {
+  for (auto& Arg : args) {
     if (Arg.free())
       continue;
 
@@ -63,6 +64,17 @@ vector<Value*> tesla::CollectArgs(
   }
 
   return Args;
+}
+
+vector<Value*> tesla::CollectArgs(
+    Instruction *Before, const Automaton& A,
+    Module& Mod, IRBuilder<>& Builder) {
+
+  vector<Argument> newArgs;
+  auto args = A.getAssertion().argument();
+
+  std::copy(args.begin(), args.end(), std::back_inserter(newArgs));
+  return tesla::CollectArgs(Before, newArgs, Mod, Builder);
 }
 
 Value* tesla::GetArgumentValue(Value* Param, const Argument& ArgDescrip,

--- a/tesla/common/Arguments.h
+++ b/tesla/common/Arguments.h
@@ -27,6 +27,10 @@ class Automaton;
 std::vector<llvm::Value*> CollectArgs(llvm::Instruction *, const Automaton&,
                                       llvm::Module&, llvm::IRBuilder<>&);
 
+//!
+std::vector<llvm::Value*> CollectArgs(llvm::Instruction *, std::vector<Argument>,
+                                      llvm::Module&, llvm::IRBuilder<>&);
+
 //! Poke through indirection, struct fields, etc.
 llvm::Value* GetArgumentValue(llvm::Value* Param, const Argument& ArgDescrip,
                               llvm::IRBuilder<>& Builder,

--- a/tesla/common/Arguments.h
+++ b/tesla/common/Arguments.h
@@ -28,7 +28,7 @@ std::vector<llvm::Value*> CollectArgs(llvm::Instruction *, const Automaton&,
                                       llvm::Module&, llvm::IRBuilder<>&);
 
 //!
-std::vector<llvm::Value*> CollectArgs(llvm::Instruction *, std::vector<Argument>,
+std::vector<llvm::Value*> CollectArgs(llvm::Instruction *, std::vector<tesla::Argument>,
                                       llvm::Module&, llvm::IRBuilder<>&);
 
 //! Poke through indirection, struct fields, etc.

--- a/tesla/common/Manifest.cpp
+++ b/tesla/common/Manifest.cpp
@@ -84,6 +84,13 @@ const Automaton* Manifest::FindAutomaton(const Location& Loc) const {
   return FindAutomaton(ID);
 }
 
+const Automaton* Manifest::FindAutomaton(std::string name) const {
+  Identifier ID;
+  *ID.mutable_name() = name;
+
+  return FindAutomaton(ID);
+}
+
 Manifest* 
 Manifest::construct(raw_ostream& ErrorStream, 
                     Automaton::Type T, 

--- a/tesla/common/Manifest.h
+++ b/tesla/common/Manifest.h
@@ -72,6 +72,9 @@ public:
   //! Find the @ref tesla::Automaton defined at a @ref tesla::Location.
   const Automaton* FindAutomaton(const Location&) const;
 
+  //! Find the @red tesla::Automaton with this name
+  const Automaton* FindAutomaton(std::string name) const;
+
   const llvm::ArrayRef<Automaton::Lifetime> getLifetimes() const {
     return Lifetimes;
   }

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -1,4 +1,5 @@
 #include "AcquireReleaseCheck.h"
+#include "ControlPath.h"
 
 AcquireReleaseCheck::AcquireReleaseCheck(const tesla::Automaton &A, 
                                          std::vector<tesla::Argument> args_) : 
@@ -37,6 +38,7 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
   }
 
   Value *lock = Args[0];
+  auto calledFunctions = tesla::CalledFunctions(BoundFn);
 
   return true;
 }

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -26,6 +26,18 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
   IRBuilder<> B(first);
 
   std::vector<Value *> Args(tesla::CollectArgs(first, args, M, B));
+  
+  /**
+   * For now, the automata being analysed should only have a single parameter
+   * (the lock structure in question).
+   */
+  if(Args.size() != 1) {
+    errs() << "Automata has more than one parameter\n";
+    return true;
+  }
+
+  Value *lock = Args[0];
+
   return true;
 }
   

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -1,9 +1,12 @@
 #include "AcquireReleaseCheck.h"
 
-AcquireReleaseCheck::AcquireReleaseCheck(string bound) : 
+AcquireReleaseCheck::AcquireReleaseCheck(const tesla::Automaton &A) : 
   ModulePass(ID), 
   correctUsage(false),
-  boundName(bound) {}
+  boundName(A.Use()->beginning().function().function().name()),
+  automaton(A)
+{
+}
 
 void AcquireReleaseCheck::getAnalysisUsage(AnalysisUsage &AU) const {
 }

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -9,6 +9,13 @@ void AcquireReleaseCheck::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 bool AcquireReleaseCheck::runOnModule(Module &M) {
+  auto BoundFn = M.getFunction(boundName);
+  if(!BoundFn) {
+    errs() << "Bounding function " << boundName
+           << " does not exist in this module.\n";
+    return false;
+  }
+
   return true;
 }
   

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -19,6 +19,12 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
     return false;
   }
 
+  BasicBlock &entry = BoundFn->getEntryBlock();
+  Instruction *first = entry.getFirstNonPHIOrDbgOrLifetime();
+  IRBuilder<> B(first);
+
+  std::vector<Value *> args(tesla::CollectArgs(first, automaton, M, B));
+
   return true;
 }
   

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -45,4 +45,8 @@ void AcquireReleaseCheck::print(raw_ostream &OS, const Module *m) const {
   OS << "[AcqRel] correct usage: " << correctUsage << '\n';
 }
 
+const char *AcquireReleaseCheck::getPassName() const {
+  return "AcquireReleaseCheck";
+}
+
 char AcquireReleaseCheck::ID = 0;

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -1,10 +1,12 @@
 #include "AcquireReleaseCheck.h"
 
-AcquireReleaseCheck::AcquireReleaseCheck(const tesla::Automaton &A) : 
+AcquireReleaseCheck::AcquireReleaseCheck(const tesla::Automaton &A, 
+                                         std::vector<tesla::Argument> args_) : 
   ModulePass(ID), 
   correctUsage(false),
   boundName(A.Use()->beginning().function().function().name()),
-  automaton(A)
+  automaton(A),
+  args(args_)
 {
 }
 
@@ -23,8 +25,7 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
   Instruction *first = entry.getFirstNonPHIOrDbgOrLifetime();
   IRBuilder<> B(first);
 
-  std::vector<Value *> args(tesla::CollectArgs(first, automaton, M, B));
-
+  std::vector<Value *> Args(tesla::CollectArgs(first, args, M, B));
   return true;
 }
   

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -22,6 +22,7 @@ struct AcquireReleaseCheck : public ModulePass {
 
   virtual bool runOnModule(Module &M);
   virtual void getAnalysisUsage(AnalysisUsage &AU) const;
+  virtual const char *getPassName() const;
   void print(raw_ostream &OS, const Module *m = 0) const;
   static char ID;
 private:

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -7,11 +7,13 @@
 
 #include <string>
 
+#include "Automaton.h"
+
 using std::string;
 using namespace llvm;
 
 struct AcquireReleaseCheck : public ModulePass {
-  AcquireReleaseCheck(string bound);
+  AcquireReleaseCheck(const tesla::Automaton &A);
   
   bool CorrectUsage() { return correctUsage; }
 
@@ -21,7 +23,8 @@ struct AcquireReleaseCheck : public ModulePass {
   static char ID;
 private:
   bool correctUsage;
-  string boundName;
+  const string boundName;
+  const tesla::Automaton &automaton;
 };
 
 #endif

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -3,11 +3,13 @@
 
 #include <llvm/Pass.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include <string>
 
 #include "Automaton.h"
+#include "Arguments.h"
 
 using std::string;
 using namespace llvm;

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -7,6 +7,7 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <string>
+#include <vector>
 
 #include "Automaton.h"
 #include "Arguments.h"
@@ -15,7 +16,7 @@ using std::string;
 using namespace llvm;
 
 struct AcquireReleaseCheck : public ModulePass {
-  AcquireReleaseCheck(const tesla::Automaton &A);
+  AcquireReleaseCheck(const tesla::Automaton &A, std::vector<tesla::Argument> args);
   
   bool CorrectUsage() { return correctUsage; }
 
@@ -27,6 +28,7 @@ private:
   bool correctUsage;
   const string boundName;
   const tesla::Automaton &automaton;
+  std::vector<tesla::Argument> args;
 };
 
 #endif

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -6,6 +6,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/Support/raw_ostream.h>
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -20,6 +21,7 @@ struct AcquireReleaseCheck : public ModulePass {
   
   bool CorrectUsage() { return correctUsage; }
 
+  Value *UsesOtherLock(Value *lock, std::set<Function *> calls);
   virtual bool runOnModule(Module &M);
   virtual void getAnalysisUsage(AnalysisUsage &AU) const;
   virtual const char *getPassName() const;

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -38,7 +38,7 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
     newRoot->CopyFrom(*root);
 
     if(UsesAcqRel(newRoot, locs)) {
-      newRoot->set_deleted(ShouldDelete(automaton, Mod));
+      newRoot->set_deleted(ShouldDelete(automaton, args, Mod));
     }
     
     copyUsage(newRoot, File);
@@ -49,7 +49,9 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
       Manifest::construct(llvm::errs(), Automaton::Deterministic, std::move(unique)));
 }
 
-bool AcquireReleasePass::ShouldDelete(const Automaton *A, llvm::Module &Mod) {
+bool AcquireReleasePass::ShouldDelete(const Automaton *A, 
+                                      std::vector<Argument> args, 
+                                      llvm::Module &Mod) {
   /**
    * For now, we will only be working on usages that have their entry point as
    * the entry to a function, and their exit as an exit from that same function.
@@ -64,7 +66,7 @@ bool AcquireReleasePass::ShouldDelete(const Automaton *A, llvm::Module &Mod) {
   }
 
   PassManager passes;
-  auto check = new AcquireReleaseCheck(*A);
+  auto check = new AcquireReleaseCheck(*A, args);
   passes.add(check);
   passes.run(Mod);
 

--- a/tesla/static/AcquireReleasePass.cpp
+++ b/tesla/static/AcquireReleasePass.cpp
@@ -1,10 +1,12 @@
-#include "AcquireReleasePass.h"
-
 #include "AcquireReleaseCheck.h"
+#include "AcquireReleasePass.h"
 #include "Debug.h"
 
 #include <llvm/PassManager.h>
 #include <llvm/Support/raw_ostream.h>
+
+#include <algorithm>
+#include <vector>
 
 using std::unique_ptr;
 using std::set;
@@ -15,6 +17,15 @@ unique_ptr<Manifest> AcquireReleasePass::run(Manifest &Man, llvm::Module &Mod) {
   auto File = new ManifestFile();
 
   copyDefinitions(Man, File);
+
+  // TODO: check that the arguments are equal
+  auto acq = Man.FindAutomaton("acquire");
+  auto rel = Man.FindAutomaton("release");
+  std::vector<Argument> args;
+
+  std::copy(acq->getAssertion().argument().begin(), 
+            acq->getAssertion().argument().end(), 
+            std::back_inserter(args));
 
   auto locs = ReferenceLocations(Man);
   for(auto root : Man.RootAutomata()) {

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -17,7 +17,8 @@ class AcquireReleasePass : public ManifestPass {
     static bool UsesAcqRel(const Usage *usage, set<const Location> &locs);
     static bool ReferencesAcqRel(const AutomatonDescription *aut);
     static set<const Location> ReferenceLocations(Manifest &Man);
-    static bool ShouldDelete(const Automaton *A, llvm::Module &Mod);
+    static bool ShouldDelete(const Automaton *A, std::vector<Argument> args, 
+                             llvm::Module &Mod);
     static bool HasSimpleBounds(const Usage *usage);
     static std::string SimpleBoundFunction(const Usage *usage);
 };

--- a/tesla/static/AcquireReleasePass.h
+++ b/tesla/static/AcquireReleasePass.h
@@ -17,9 +17,9 @@ class AcquireReleasePass : public ManifestPass {
     static bool UsesAcqRel(const Usage *usage, set<const Location> &locs);
     static bool ReferencesAcqRel(const AutomatonDescription *aut);
     static set<const Location> ReferenceLocations(Manifest &Man);
-    static bool ShouldDelete(Usage *usage, llvm::Module &Mod);
-    static bool HasSimpleBounds(Usage *usage);
-    static std::string SimpleBoundFunction(Usage *usage);
+    static bool ShouldDelete(const Automaton *A, llvm::Module &Mod);
+    static bool HasSimpleBounds(const Usage *usage);
+    static std::string SimpleBoundFunction(const Usage *usage);
 };
 
 }

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -9,6 +9,7 @@ add_llvm_executable(tesla-static
   ManifestPassManager.cpp
   AcquireReleasePass.cpp
   AcquireReleaseCheck.cpp
+  ControlPath.cpp
 )
 
 target_link_libraries(tesla-static

--- a/tesla/static/ControlPath.cpp
+++ b/tesla/static/ControlPath.cpp
@@ -1,0 +1,5 @@
+#include "ControlPath.h"
+
+std::vector<Function *> tesla::CalledFunctions(Function *root) {
+  return { root };
+}

--- a/tesla/static/ControlPath.cpp
+++ b/tesla/static/ControlPath.cpp
@@ -1,5 +1,40 @@
 #include "ControlPath.h"
 
-std::vector<Function *> tesla::CalledFunctions(Function *root) {
-  return { root };
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/Casting.h>
+
+#include <set>
+#include <queue>
+
+using std::set;
+using std::queue;
+
+set<Function *> tesla::CalledFunctions(Function *root) {
+  queue<Function *> toVisit;
+  toVisit.push(root);
+
+  set<Function *> called;
+
+  while(!toVisit.empty()) {
+    Function *next = toVisit.front();
+    toVisit.pop();
+    called.insert(next);
+
+    for(auto &BB : *next) {
+      for(auto &I : BB) {
+        if(isa<CallInst>(I)) {
+          auto &call = cast<CallInst>(I);
+          const auto fn = call.getCalledFunction();
+          if(fn && !fn->isDeclaration()) {
+            if(called.find(fn) == called.end()) {
+              toVisit.push(fn);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return called;
 }

--- a/tesla/static/ControlPath.h
+++ b/tesla/static/ControlPath.h
@@ -1,0 +1,16 @@
+#ifndef CONTROL_PATH_H
+#define CONTROL_PATH_H
+
+#include <llvm/IR/Function.h>
+
+#include <vector>
+
+using namespace llvm;
+
+namespace tesla {
+
+std::vector<Function *> CalledFunctions(Function *root);
+
+}
+
+#endif

--- a/tesla/static/ControlPath.h
+++ b/tesla/static/ControlPath.h
@@ -3,13 +3,13 @@
 
 #include <llvm/IR/Function.h>
 
-#include <vector>
+#include <set>
 
 using namespace llvm;
 
 namespace tesla {
 
-std::vector<Function *> CalledFunctions(Function *root);
+std::set<Function *> CalledFunctions(Function *root);
 
 }
 


### PR DESCRIPTION
This PR introduces the first actual static analysis implemented. When run, it checks for usages of `acq_rel`, and ensures that within the simple bounds used, calls to the acquire and release functions are *only* made with the argument passed to the assertion.