### PR TITLE
Add debug location function to common library

### DIFF
--- a/tesla/common/Debug.cpp
+++ b/tesla/common/Debug.cpp
@@ -94,6 +94,13 @@ raw_ostream& tesla::debugs(StringRef DebugModuleName) {
   return NullStream;
 }
 
+std::string tesla::DebugLocationString(Instruction *I) {
+  auto DI = I->getDebugLoc();
+  return I->getParent()->getParent()->getParent()->getModuleIdentifier() + ":" +
+         I->getParent()->getParent()->getName().str() + ":" +
+         std::to_string(DI.getLine());
+}
+
 #ifndef NDEBUG
 #include <llvm/Support/Signals.h>
 

--- a/tesla/common/Debug.h
+++ b/tesla/common/Debug.h
@@ -34,6 +34,12 @@
 
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/Twine.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+#include <string>
 
 namespace llvm {
   class raw_ostream;
@@ -45,6 +51,8 @@ llvm::raw_ostream& debugs(llvm::StringRef DebugModuleName = "tesla");
 
 LLVM_ATTRIBUTE_NORETURN
 void panic(llvm::Twine Message, bool PrintStackTrace = true);
+
+std::string DebugLocationString(llvm::Instruction *I);
 
 #ifdef NDEBUG
 #define __debugonly __attribute__((unused))


### PR DESCRIPTION
This method gives a string representing the location of an Instruction as best as can be determined (currently it is module:function:line, as getting back to a source file is not possible in LLVM 3.4 - in a later version, getFilename is available)