### PR TITLE
Simple call graph

### DIFF
--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -14,6 +14,7 @@ add_llvm_executable(tesla-static
   OtherLockAnalysis.cpp
   NoBranchAnalysis.cpp
   ReleaseBeforeAcquireAnalysis.cpp
+  SimpleCallGraph.cpp
 )
 
 target_link_libraries(tesla-static

--- a/tesla/static/SimpleCallGraph.cpp
+++ b/tesla/static/SimpleCallGraph.cpp
@@ -1,0 +1,1 @@
+#include "SimpleCallGraph.h"

--- a/tesla/static/SimpleCallGraph.cpp
+++ b/tesla/static/SimpleCallGraph.cpp
@@ -2,16 +2,45 @@
 
 #include <llvm/IR/Instructions.h>
 
+#include <queue>
+#include <set>
+
+using std::queue;
+using std::set;
+
 SimpleCallGraph::SimpleCallGraph(Module &M) {
   for(auto &F : M) {
-    Adjacency[&F] = getAdjacency(&F);
+    Adjacency[&F] = getAdjacency(F);
   }
 }
 
-vector<Function *> SimpleCallGraph::getAdjacency(Function *f) {
+vector<Function *> SimpleCallGraph::TransitiveCalls(Function *root) {
+  queue<Function *> toVisit{};
+  set<Function *> found{};
+
+  toVisit.push(root);
+
+  while(!toVisit.empty()) {
+    auto fn = toVisit.front();
+
+    for(auto called : Calls(fn)) {
+      if(std::find(found.begin(), found.end(), called) == found.end()) {
+        found.insert(called); 
+        toVisit.push(called);
+      }
+    }
+  }
+
+  vector<Function *>ret{};
+  std::copy(found.begin(), found.end(), ret.begin());
+
+  return ret;
+}
+
+vector<Function *> SimpleCallGraph::getAdjacency(Function &f) {
   vector<Function *> called{};
 
-  for(auto &BB : *f) {
+  for(auto &BB : f) {
     for(auto &I : BB) {
       if(isa<CallInst>(I)) {
         auto &call = cast<CallInst>(I);

--- a/tesla/static/SimpleCallGraph.cpp
+++ b/tesla/static/SimpleCallGraph.cpp
@@ -1,1 +1,24 @@
 #include "SimpleCallGraph.h"
+
+#include <llvm/IR/Instructions.h>
+
+SimpleCallGraph::SimpleCallGraph(Module &M) {
+  for(auto &F : M) {
+    Adjacency[&F] = getAdjacency(&F);
+  }
+}
+
+vector<Function *> SimpleCallGraph::getAdjacency(Function *f) {
+  vector<Function *> called{};
+
+  for(auto &BB : *f) {
+    for(auto &I : BB) {
+      if(isa<CallInst>(I)) {
+        auto &call = cast<CallInst>(I);
+        called.push_back(call.getCalledFunction());
+      }
+    }
+  }
+
+  return called;
+}

--- a/tesla/static/SimpleCallGraph.h
+++ b/tesla/static/SimpleCallGraph.h
@@ -18,9 +18,20 @@ struct SimpleCallGraph {
    */
   SimpleCallGraph(Module &M);
 
+  /**
+   * Return all the functions called directly by the parameter.
+   */
+  inline vector<Function *> Calls(Function *f) {
+    return Adjacency[f];
+  }
+
+  /**
+   * Return all the functions called (even transitively) by the parameter.
+   */
+  vector<Function *> TransitiveCalls(Function *f);
 private:
   map<Function *, vector<Function *>> Adjacency;
-  static vector<Function *> getAdjacency(Function *f);
+  static vector<Function *> getAdjacency(Function &f);
 };
 
 #endif

--- a/tesla/static/SimpleCallGraph.h
+++ b/tesla/static/SimpleCallGraph.h
@@ -1,0 +1,4 @@
+#ifndef SIMPLE_CALL_GRAPH_H
+#define SIMPLE_CALL_GRAPH_H
+
+#endif

--- a/tesla/static/SimpleCallGraph.h
+++ b/tesla/static/SimpleCallGraph.h
@@ -1,4 +1,26 @@
 #ifndef SIMPLE_CALL_GRAPH_H
 #define SIMPLE_CALL_GRAPH_H
 
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
+
+#include <map>
+#include <vector>
+
+using std::map;
+using std::vector;
+using namespace llvm;
+
+struct SimpleCallGraph {
+  
+  /**
+   * Construct a call graph from the given module.
+   */
+  SimpleCallGraph(Module &M);
+
+private:
+  map<Function *, vector<Function *>> Adjacency;
+  static vector<Function *> getAdjacency(Function *f);
+};
+
 #endif


### PR DESCRIPTION
This PR implements a simple call graph structure so that I don't have to keep on grappling with the LLVM implementation. This just allows for the construction of a vector of transitive or non-transitive calls that a function makes.