### PR TITLE
Missing call analysis

### DIFF
--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -1,8 +1,9 @@
 #include "AcquireReleaseCheck.h"
 #include "ControlPath.h"
 #include "CallOrderAnalysis.h"
-#include "OtherLockAnalysis.h"
+#include "MissingCallAnalysis.h"
 #include "NoBranchAnalysis.h"
+#include "OtherLockAnalysis.h"
 #include "ReleaseBeforeAcquireAnalysis.h"
 
 #include <llvm/Analysis/CallGraph.h>
@@ -45,6 +46,7 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
   }
 
   std::vector<Analysis *> Analyses{
+    new MissingCallAnalysis(M, *BoundFn),
     new OtherLockAnalysis(M, *BoundFn, *Args[0]),
     new NoBranchAnalysis(M),
     new ReleaseBeforeAcquireAnalysis(M, *BoundFn, *Args[0]),

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -15,6 +15,7 @@ add_llvm_executable(tesla-static
   NoBranchAnalysis.cpp
   ReleaseBeforeAcquireAnalysis.cpp
   CallOrderAnalysis.cpp
+  MissingCallAnalysis.cpp
   SimpleCallGraph.cpp
 )
 

--- a/tesla/static/MissingCallAnalysis.cpp
+++ b/tesla/static/MissingCallAnalysis.cpp
@@ -1,5 +1,20 @@
 #include "MissingCallAnalysis.h"
 
 bool MissingCallAnalysis::run() {
-  return false;
+  auto calls = CG.TransitiveCalls(&Bound);
+  auto acqFn = Mod.getFunction("lock_acquire");
+  auto relFn = Mod.getFunction("lock_release");
+  bool missing = false;
+  
+  if(std::find(calls.begin(), calls.end(), acqFn) == calls.end()) {
+    AddMessage("No call to lock_acquire found");
+    missing = true;
+  }
+
+  if(std::find(calls.begin(), calls.end(), relFn) == calls.end()) {
+    AddMessage("No call to lock_release found");
+    missing = true;
+  }
+
+  return missing;
 }

--- a/tesla/static/MissingCallAnalysis.cpp
+++ b/tesla/static/MissingCallAnalysis.cpp
@@ -1,0 +1,5 @@
+#include "MissingCallAnalysis.h"
+
+bool MissingCallAnalysis::run() {
+  return false;
+}

--- a/tesla/static/MissingCallAnalysis.h
+++ b/tesla/static/MissingCallAnalysis.h
@@ -1,0 +1,18 @@
+#ifndef MISSING_CALL_ANALYSIS_H
+#define MISSING_CALL_ANALYSIS_H
+
+#include "Analysis.h"
+
+using namespace llvm;
+
+struct MissingCallAnalysis : public Analysis {
+  MissingCallAnalysis(Module &M, Function &F) :
+    Analysis(M), Bound(F) {}
+
+  std::string AnalysisName() const override { return "MissingCallAnalysis"; }
+  bool run() override;
+private:
+  Function &Bound;
+};
+
+#endif

--- a/tesla/static/MissingCallAnalysis.h
+++ b/tesla/static/MissingCallAnalysis.h
@@ -2,16 +2,18 @@
 #define MISSING_CALL_ANALYSIS_H
 
 #include "Analysis.h"
+#include "SimpleCallGraph.h"
 
 using namespace llvm;
 
 struct MissingCallAnalysis : public Analysis {
   MissingCallAnalysis(Module &M, Function &F) :
-    Analysis(M), Bound(F) {}
+    Analysis(M), CG(M), Bound(F) {}
 
   std::string AnalysisName() const override { return "MissingCallAnalysis"; }
   bool run() override;
 private:
+  SimpleCallGraph CG;
   Function &Bound;
 };
 


### PR DESCRIPTION
This analysis checks that there is at least one call to each of `lock_acquire` and `lock_release` within the bounds.