### PR TITLE
Release dominance

### DIFF
--- a/experiments/locks/mult_rel.c
+++ b/experiments/locks/mult_rel.c
@@ -12,8 +12,21 @@
 
 lock_t lock;
 
+void baz(void) {
+  lock_release(&lock);
+}
+
+void bar(void) {
+  baz();
+}
+
+void foo(void) {
+  bar();
+}
+
 void do_work(void) {
   while(!lock_acquire(&lock)) {}
   lock_release(&lock);
   lock_release(&lock);
+  foo();
 }

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -5,6 +5,7 @@
 #include "NoBranchAnalysis.h"
 #include "OtherLockAnalysis.h"
 #include "ReleaseBeforeAcquireAnalysis.h"
+#include "ReleaseDominanceAnalysis.h"
 
 #include <llvm/Analysis/CallGraph.h>
 
@@ -47,6 +48,7 @@ bool AcquireReleaseCheck::runOnModule(Module &M) {
 
   std::vector<Analysis *> Analyses{
     new MissingCallAnalysis(M, *BoundFn),
+    new ReleaseDominanceAnalysis(M, *BoundFn),
     new OtherLockAnalysis(M, *BoundFn, *Args[0]),
     new NoBranchAnalysis(M),
     new ReleaseBeforeAcquireAnalysis(M, *BoundFn, *Args[0]),

--- a/tesla/static/CMakeLists.txt
+++ b/tesla/static/CMakeLists.txt
@@ -16,6 +16,7 @@ add_llvm_executable(tesla-static
   ReleaseBeforeAcquireAnalysis.cpp
   CallOrderAnalysis.cpp
   MissingCallAnalysis.cpp
+  ReleaseDominanceAnalysis.cpp
   ReachabilityGraph.cpp
   SimpleCallGraph.cpp
 )

--- a/tesla/static/ReachabilityGraph.cpp
+++ b/tesla/static/ReachabilityGraph.cpp
@@ -22,6 +22,10 @@ ReachabilityGraph::ReachabilityGraph(Function &F) : Func(F) {
 }
 
 bool ReachabilityGraph::Reachable(BasicBlock *start, BasicBlock *end) {
+  if(start == end) {
+    return true;
+  }
+
   set<BasicBlock *> visited;
   stack<BasicBlock *> st;
 

--- a/tesla/static/ReleaseDominanceAnalysis.cpp
+++ b/tesla/static/ReleaseDominanceAnalysis.cpp
@@ -8,8 +8,13 @@ bool ReleaseDominanceAnalysis::run() {
   auto ret = true;
   auto relFn = Mod.getFunction("lock_release");
   SimpleCallGraph CG{Mod};
+  auto path = CG.TransitiveCalls(&Bound);
 
   for(auto &F : Mod) {
+    if(std::find(path.begin(), path.end(), &F) == path.end()) {
+      continue;
+    }
+
     ReachabilityGraph RG{F};
 
     auto localRels = releases[&F];

--- a/tesla/static/ReleaseDominanceAnalysis.cpp
+++ b/tesla/static/ReleaseDominanceAnalysis.cpp
@@ -1,5 +1,52 @@
+#include "Debug.h"
+#include "ReachabilityGraph.h"
 #include "ReleaseDominanceAnalysis.h"
 
 bool ReleaseDominanceAnalysis::run() {
-  return false;
+  auto releases = ReleaseCalls();
+  auto ret = true;
+
+  for(auto &F : Mod) {
+    ReachabilityGraph RG{F};
+
+    auto localRels = releases[&F];
+    for(auto callA : localRels) {
+      for(auto callB : localRels) {
+        if(callA != callB) {
+          if(RG.Reachable(callA->getParent(), callB->getParent())) {
+            AddMessage("Release call reachable from another release call");
+            AddMessage("First call: " + tesla::DebugLocationString(callA));
+            AddMessage("Second call: " + tesla::DebugLocationString(callB));
+            ret = true;
+          }
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+map<Function *, set<CallInst *>> ReleaseDominanceAnalysis::ReleaseCalls() {
+  auto relFn = Mod.getFunction("lock_release");
+  map<Function *, set<CallInst *>> map{};
+
+  for(auto &F : Mod) {
+    set<CallInst *> calls{};
+
+    for(auto &BB : F) {
+      for(auto &I : BB) {
+        if(isa<CallInst>(I)) {
+          auto &call = cast<CallInst>(I);
+          if(call.getCalledFunction() == relFn) {
+            calls.insert(&call);
+          }
+        }
+      }
+    }
+
+    map[&F] = calls;
+  }
+
+  return map;
 }

--- a/tesla/static/ReleaseDominanceAnalysis.cpp
+++ b/tesla/static/ReleaseDominanceAnalysis.cpp
@@ -1,0 +1,5 @@
+#include "ReleaseDominanceAnalysis.h"
+
+bool ReleaseDominanceAnalysis::run() {
+  return false;
+}

--- a/tesla/static/ReleaseDominanceAnalysis.h
+++ b/tesla/static/ReleaseDominanceAnalysis.h
@@ -3,6 +3,11 @@
 
 #include "Analysis.h"
 
+#include <llvm/IR/Instructions.h>
+
+#include <set>
+
+using std::set;
 using namespace llvm;
 
 struct ReleaseDominanceAnalysis : public Analysis {
@@ -12,6 +17,7 @@ struct ReleaseDominanceAnalysis : public Analysis {
   std::string AnalysisName() const override { return "ReleaseDominanceAnalysis"; }
   bool run() override;
 private:
+  map<Function *, set<CallInst *>> ReleaseCalls();
   Function &Bound;
 };
 

--- a/tesla/static/ReleaseDominanceAnalysis.h
+++ b/tesla/static/ReleaseDominanceAnalysis.h
@@ -1,0 +1,18 @@
+#ifndef RELEASE_DOMINANCE_ANALYSIS_H
+#define RELEASE_DOMINANCE_ANALYSIS_H
+
+#include "Analysis.h"
+
+using namespace llvm;
+
+struct ReleaseDominanceAnalysis : public Analysis {
+  ReleaseDominanceAnalysis(Module &M, Function &F) :
+    Analysis(M), Bound(F) {}
+
+  std::string AnalysisName() const override { return "ReleaseDominanceAnalysis"; }
+  bool run() override;
+private:
+  Function &Bound;
+};
+
+#endif


### PR DESCRIPTION
This PR implements an analysis to check whether any release calls are reachable from a previous release call - if they are, then the lock might get released twice (causing an error).