### PR TITLE
Add safe automata find method

### DIFF
--- a/tesla/common/Manifest.cpp
+++ b/tesla/common/Manifest.cpp
@@ -91,6 +91,28 @@ const Automaton* Manifest::FindAutomaton(std::string name) const {
   return FindAutomaton(ID);
 }
 
+const Automaton* Manifest::FindAutomatonSafe(const Identifier& ID) const {
+  auto i = Automata.find(ID);
+  if (i == Automata.end())
+    return nullptr;
+
+  return i->second;
+}
+
+const Automaton* Manifest::FindAutomatonSafe(const Location& Loc) const {
+  Identifier ID;
+  *ID.mutable_location() = Loc;
+
+  return FindAutomatonSafe(ID);
+}
+
+const Automaton* Manifest::FindAutomatonSafe(std::string name) const {
+  Identifier ID;
+  *ID.mutable_name() = name;
+
+  return FindAutomatonSafe(ID);
+}
+
 Manifest* 
 Manifest::construct(raw_ostream& ErrorStream, 
                     Automaton::Type T, 

--- a/tesla/common/Manifest.h
+++ b/tesla/common/Manifest.h
@@ -75,6 +75,18 @@ public:
   //! Find the @red tesla::Automaton with this name
   const Automaton* FindAutomaton(std::string name) const;
 
+  //! Find the @ref tesla::Automaton named by an @ref tesla::Identifier.
+  //  Will return `nullptr` instead of panicking if the automaton is not found.
+  const Automaton* FindAutomatonSafe(const Identifier&) const;
+
+  //! Find the @ref tesla::Automaton defined at a @ref tesla::Location.
+  //  Will return `nullptr` instead of panicking if the automaton is not found.
+  const Automaton* FindAutomatonSafe(const Location&) const;
+  
+  //! Find the @red tesla::Automaton with this name
+  //  Will return `nullptr` instead of panicking if the automaton is not found.
+  const Automaton* FindAutomatonSafe(std::string name) const;
+
   const llvm::ArrayRef<Automaton::Lifetime> getLifetimes() const {
     return Lifetimes;
   }


### PR DESCRIPTION
This allows for automata to be searched for safely (if one is not found,
a null pointer is returned rather than a panic).