### PR TITLE
Search transitively for once calls

### DIFF
--- a/tesla/static/CallsFunctionOnce.cpp
+++ b/tesla/static/CallsFunctionOnce.cpp
@@ -4,6 +4,31 @@
 
 #include <llvm/Analysis/Dominators.h>
 
+set<Function *> tesla::TransitiveCallsOnce(Module &M, Function *callee) {
+  set<Function *> fns;
+
+  for(auto &F : M) {
+    if(CallsFunctionOnce(callee, &F)) {
+      fns.insert(&F);
+    }
+  }
+
+  auto size = -1;
+  while(size != fns.size()) {
+    size = fns.size();
+
+    for(auto &F : M) {
+      for(auto fn : fns) {
+        if(CallsFunctionOnce(fn, &F)) {
+          fns.insert(&F);
+        }
+      }
+    }
+  }
+
+  return fns;
+}
+
 bool tesla::CallsFunctionOnce(Function *callee, Function *caller) {
   auto exits = FunctionExits(caller);
   auto calls = CallsTo(callee, caller);

--- a/tesla/static/CallsFunctionOnce.h
+++ b/tesla/static/CallsFunctionOnce.h
@@ -11,6 +11,7 @@ using namespace llvm;
 
 namespace tesla {
 
+set<Function *> TransitiveCallsOnce(Module &M, Function *callee);
 bool CallsFunctionOnce(Function *callee, Function *caller);
 bool TransitiveCallsTo(Function *callee, Function *caller);
 bool ExitsDominated(Function *caller, set<ReturnInst *> es, set<CallInst *> cs);


### PR DESCRIPTION
This generalises the previous PR to search transitively for functions that must eventually call `f` exactly once.