### PR TITLE
Module Graph Tool

### DIFF
--- a/tesla/model/CMakeLists.txt
+++ b/tesla/model/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD}
 add_llvm_executable(tesla-model
   model.cpp
   EventGraph.cpp
+  GraphTransforms.cpp
 )
 
 target_link_libraries(tesla-model

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -86,6 +86,41 @@ EventGraph *EventGraph::InstructionGraph(Function *f) {
   return eg;
 }
 
+set<Event *> EventGraph::entries() {
+  map<Event *, int> counts;
+
+  for(auto ev : Events) {
+    for(auto suc : ev->successors) {
+      if(counts.find(suc) == counts.end()) {
+        counts[suc] = 0;
+      }
+
+      counts[suc]++;
+    }
+  }
+
+  set<Event *> entries;
+  for(auto ev : Events) {
+    if(counts[ev] == 0) {
+      entries.insert(ev);
+    }
+  }
+
+  return entries;
+}
+
+set<Event *> EventGraph::exits() {
+  set<Event *> exits;
+
+  for(auto ev : Events) {
+    if(ev->successors.size() == 0) {
+      exits.insert(ev);
+    }
+  }
+
+  return exits;
+}
+
 // Just a helper for now so it isn't declared in the class - might need to
 // change in the future but it's OK at the moment.
 Event *cachedTransform(map<Event *, Event *> &cache, Event *e, 

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -45,7 +45,7 @@ void EventGraph::assert_valid() {
 }
 
 EventGraph *EventGraph::BasicBlockGraph(Function *f) {
-  auto eg = new EventGraph;
+  auto eg = new EventGraph(f->getName().str());
 
   map<BasicBlock *, Event *> cache;
 
@@ -271,14 +271,17 @@ EventRange *EventRange::Create(EventGraph *g, BasicBlock *bb) {
 string EventGraph::GraphViz() const {
   std::stringstream ss;
 
-  ss << "digraph {\n";
+  ss << "digraph " << Name << " {\n";
+  ss << "  " << GraphVizStyle() << '\n';
+
   for(auto ev : Events) {
-    ss << "\"" << ev->GraphViz() << "\"" << '\n';
+    ss << "  \"" << ev->GraphViz() << "\"" << '\n';
     for(auto suc : ev->successors) {
-      ss << "\"" << ev->GraphViz() << "\" -> \""
+      ss << "  \"" << ev->GraphViz() << "\" -> \""
          << suc->GraphViz() << "\";\n";
     }
   }
+
   ss << "}\n";
 
   return ss.str();

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -121,6 +121,12 @@ set<Event *> EventGraph::exits() {
   return exits;
 }
 
+void EventGraph::releaseAllEvents() {
+  for(auto ev : Events) {
+    ev->Graph = nullptr;
+  }
+}
+
 // Just a helper for now so it isn't declared in the class - might need to
 // change in the future but it's OK at the moment.
 Event *cachedTransform(map<Event *, Event *> &cache, Event *e, 

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -1,5 +1,7 @@
 #include "EventGraph.h"
 
+#include <llvm/Support/CFG.h>
+
 #include <map>
 #include <queue>
 #include <set>
@@ -50,6 +52,11 @@ EventGraph *EventGraph::BasicBlockGraph(Function *f) {
   map<BasicBlock *, Event *> cache;
 
   for(auto &BB : *f) {
+    // In this case the basic block is statically unreachable so we don't emit
+    // an event for it.
+    if(pred_begin(&BB) == pred_end(&BB) && 
+       &BB != &f->getEntryBlock()) { continue; }
+
     if(cache.find(&BB) == cache.end()) {
       cache[&BB] = new BasicBlockEvent(eg, &BB);
     }

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -95,7 +95,9 @@ set<Event *> EventGraph::entries() {
         counts[suc] = 0;
       }
 
-      counts[suc]++;
+      if(ev != suc) {
+        counts[suc]++;
+      }
     }
   }
 
@@ -113,7 +115,9 @@ set<Event *> EventGraph::exits() {
   set<Event *> exits;
 
   for(auto ev : Events) {
-    if(ev->successors.size() == 0) {
+    if(ev->successors.size() == 0 ||
+       (ev->successors.size() == 1 && ev->successors.find(ev) != ev->successors.end()))
+    {
       exits.insert(ev);
     }
   }

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -82,8 +82,33 @@ EventGraph *EventGraph::InstructionGraph(Function *f) {
     auto range = EventRange::Create(eg, bbe->Block);
     eg->replace(bbe, range);
   }
+
+  auto ent = new EntryEvent(eg, f->getName().str());
+  for(auto e : eg->entries()) {
+    if(e != ent) {
+      ent->addSuccessor(e);
+    }
+  }
+
+  auto ex = new ExitEvent(eg, f->getName().str());
+  for(auto e : eg->exits()) {
+    if(e != ex) {
+      e->addSuccessor(ex);
+    }
+  }
   
   return eg;
+}
+
+EventRange *EventGraph::ReleasedRange() {
+  auto ents = entries();
+  auto exs = exits();
+
+  assert(ents.size() == 1 && "Can't get released range for multiple entries");
+  assert(exs.size() == 1 && "Can't get released range for multiple exs");
+
+  releaseAllEvents();
+  return new EventRange{*ents.begin(), *exs.begin()}; 
 }
 
 set<Event *> EventGraph::entries() {

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -108,11 +108,10 @@ EventGraph *EventGraph::InstructionGraph(Function *f) {
   return eg;
 }
 
-EventGraph *EventGraph::ModuleGraph(Module *M, Function *root) {
+EventGraph *EventGraph::ModuleGraph(Module *M, Function *root, int depth) {
   EventGraph *eg = InstructionGraph(root);
   eg->transform(GraphTransforms::CallsOnly);
 
-  int depth = 5;
   for(int i = 0; i < depth; i++) {
     auto EventsCopy = eg->Events;
     for(auto ev : EventsCopy) {
@@ -141,6 +140,7 @@ EventGraph *EventGraph::ModuleGraph(Module *M, Function *root) {
     }
   }
 
+  eg->transform(GraphTransforms::DeleteCalls);
   return eg;
 }
 

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -41,7 +41,7 @@ struct EventGraph {
 
   static EventGraph *BasicBlockGraph(Function *f);
   static EventGraph *InstructionGraph(Function *f);
-  static EventGraph *ModuleGraph(Module *M, Function *root);
+  static EventGraph *ModuleGraph(Module *M, Function *root, int depth);
 
   set<Event *> entries();
   set<Event *> exits();

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -40,6 +40,9 @@ struct EventGraph {
   static EventGraph *BasicBlockGraph(Function *f);
   static EventGraph *InstructionGraph(Function *f);
 
+  set<Event *> entries();
+  set<Event *> exits();
+
   string GraphViz() const;
 private:
   void consolidate();

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -30,8 +30,6 @@ struct EventGraph {
 
   EventGraph() {}
 
-  void assert_valid();
-
   void replace(Event *from, Event *to);
   void replace(Event *from, EventRange *to);
 
@@ -43,10 +41,12 @@ struct EventGraph {
   set<Event *> entries();
   set<Event *> exits();
 
-  void releaseAllEvents();
+  EventRange *ReleasedRange();
 
   string GraphViz() const;
 private:
+  void releaseAllEvents();
+  void assert_valid();
   void consolidate();
   set<Event *> Events;
 };

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -59,7 +59,9 @@ struct Event {
     EV_Instruction,
     EV_Empty,
     EV_BasicBlock,
-    EV_Call
+    EV_Call,
+    EV_Enter,
+    EV_Exit
   };
 
   static Event *Create(Instruction *I);
@@ -76,6 +78,8 @@ struct Event {
     assert((Graph == nullptr || Graph == g) && "Can't re-register event!");
     Graph = g;
   }
+
+  void addSuccessor(Event *e) { successors.insert(e); }
 
   EventKind getKind() const { return Kind; }
 protected:
@@ -156,6 +160,42 @@ struct BasicBlockEvent : public Event {
   }
 
   BasicBlock *Block;
+};
+
+struct EntryEvent : public Event {
+  EntryEvent(EventGraph *g, string n)
+    : Event(EV_Enter, g), Description(n) {}
+
+  EntryEvent(string n)
+    : EntryEvent(nullptr, n) {}
+
+  const string Description;
+
+  virtual string Name() const override {
+    return "enter:" + Description;
+  }
+
+  static bool classof(const Event *other) {
+    return other->getKind() == EV_Enter;
+  }
+};
+
+struct ExitEvent : public Event {
+  ExitEvent(EventGraph *g, string n)
+    : Event(EV_Enter, g), Description(n) {}
+
+  ExitEvent(string n)
+    : ExitEvent(nullptr, n) {}
+
+  const string Description;
+
+  virtual string Name() const override {
+    return "exit:" + Description;
+  }
+
+  static bool classof(const Event *other) {
+    return other->getKind() == EV_Exit;
+  }
 };
 
 struct EventRange {

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -43,6 +43,8 @@ struct EventGraph {
   set<Event *> entries();
   set<Event *> exits();
 
+  void releaseAllEvents();
+
   string GraphViz() const;
 private:
   void consolidate();

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -28,7 +28,11 @@ struct EventGraph {
 
   using EventTransformation = std::function<Event *(Event *)>;
 
-  EventGraph() {}
+  EventGraph(string n)
+    : Name(n) {}
+
+  EventGraph() 
+    : EventGraph("") {}
 
   void replace(Event *from, Event *to);
   void replace(Event *from, EventRange *to);
@@ -49,6 +53,11 @@ private:
   void assert_valid();
   void consolidate();
   set<Event *> Events;
+  string Name;
+
+  string GraphVizStyle() const {
+    return "node [shape = none]";
+  }
 };
 
 struct Event {

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -41,6 +41,7 @@ struct EventGraph {
 
   static EventGraph *BasicBlockGraph(Function *f);
   static EventGraph *InstructionGraph(Function *f);
+  static EventGraph *ModuleGraph(Module *M, Function *root);
 
   set<Event *> entries();
   set<Event *> exits();
@@ -178,7 +179,7 @@ struct EntryEvent : public Event {
   EntryEvent(string n)
     : EntryEvent(nullptr, n) {}
 
-  const string Description;
+  string Description;
 
   virtual string Name() const override {
     return "enter:" + Description;
@@ -196,7 +197,7 @@ struct ExitEvent : public Event {
   ExitEvent(string n)
     : ExitEvent(nullptr, n) {}
 
-  const string Description;
+  string Description;
 
   virtual string Name() const override {
     return "exit:" + Description;
@@ -214,6 +215,8 @@ struct EventRange {
 
   Event *const begin;
   Event *const end;
+
+  set<Event *> Events;
 };
 
 #endif

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -17,3 +17,17 @@ Event *GraphTransforms::CallsOnly(Event *e) {
 
   assert(false && "Non instruction event in calls only transform");
 }
+
+Event *GraphTransforms::Tag::operator()(Event *e) {
+  if(e == ev) {
+    if(auto en = dyn_cast<EntryEvent>(e)) {
+      en->Description += str_;
+    }
+
+    if(auto ex = dyn_cast<ExitEvent>(e)) {
+      ex->Description += str_;
+    }
+  }
+
+  return e;
+}

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -1,5 +1,19 @@
 #include "GraphTransforms.h"
 
 Event *GraphTransforms::CallsOnly(Event *e) {
-  return nullptr;
+  if(auto ie = dyn_cast<InstructionEvent>(e)) {
+    if(auto ci = dyn_cast<CallInst>(ie->Instr())) {
+      if(!ci->getCalledFunction()->isDeclaration()) {
+        return new CallEvent(ci);
+      }
+    }
+    
+    return new EmptyEvent;
+  }
+
+  if(isa<EntryEvent>(e) || isa<ExitEvent>(e)) {
+    return e;
+  }
+
+  assert(false && "Non instruction event in calls only transform");
 }

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -1,0 +1,5 @@
+#include "GraphTransforms.h"
+
+Event *GraphTransforms::CallsOnly(Event *e) {
+  return nullptr;
+}

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -3,7 +3,8 @@
 Event *GraphTransforms::CallsOnly(Event *e) {
   if(auto ie = dyn_cast<InstructionEvent>(e)) {
     if(auto ci = dyn_cast<CallInst>(ie->Instr())) {
-      if(!ci->getCalledFunction()->isDeclaration()) {
+      auto called = ci->getCalledFunction();
+      if(called && !called->isDeclaration()) {
         return new CallEvent(ci);
       }
     }
@@ -16,6 +17,14 @@ Event *GraphTransforms::CallsOnly(Event *e) {
   }
 
   assert(false && "Non instruction event in calls only transform");
+}
+
+Event *GraphTransforms::DeleteCalls(Event *e) {
+  if(isa<CallEvent>(e)) {
+    return new EmptyEvent;
+  }
+
+  return e;
 }
 
 Event *GraphTransforms::Tag::operator()(Event *e) {

--- a/tesla/model/GraphTransforms.h
+++ b/tesla/model/GraphTransforms.h
@@ -1,0 +1,12 @@
+#ifndef GRAPH_TRANSFORMS_H
+#define GRAPH_TRANSFORMS_H
+
+#include "EventGraph.h"
+
+namespace GraphTransforms {
+
+Event *CallsOnly(Event *e);
+
+}
+
+#endif

--- a/tesla/model/GraphTransforms.h
+++ b/tesla/model/GraphTransforms.h
@@ -7,6 +7,17 @@ namespace GraphTransforms {
 
 Event *CallsOnly(Event *e);
 
+struct Tag{
+  Tag(Event *e, string s) :
+    ev(e), str_(s) {}
+
+  Event *operator()(Event *e);
+
+private:
+  Event *ev;
+  string str_;
+};
+
 }
 
 #endif

--- a/tesla/model/GraphTransforms.h
+++ b/tesla/model/GraphTransforms.h
@@ -6,6 +6,7 @@
 namespace GraphTransforms {
 
 Event *CallsOnly(Event *e);
+Event *DeleteCalls(Event *e);
 
 struct Tag{
   Tag(Event *e, string s) :

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -9,6 +9,7 @@
 #include <queue>
 
 #include "EventGraph.h"
+#include "GraphTransforms.h"
 
 using std::map;
 using std::queue;
@@ -36,23 +37,7 @@ int main(int argc, char **argv) {
 
     errs() << F.getName().str() << '\n';
 
-    eg->transform(
-      [=](Event *e) -> Event * { 
-        if(auto ie = dyn_cast<InstructionEvent>(e)) {
-          if(auto ci = dyn_cast<CallInst>(ie->Instr())) {
-            if(!ci->getCalledFunction()->isDeclaration()) {
-              return new CallEvent(ci);
-            }
-          }
-        }
-
-        if(isa<EntryEvent>(e) || isa<ExitEvent>(e)) {
-          return e;
-        }
-
-        return new EmptyEvent;
-      }
-    );
+    eg->transform(GraphTransforms::CallsOnly);
 
     errs() << eg->GraphViz();
   }

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -34,9 +34,6 @@ int main(int argc, char **argv) {
     if(F.isDeclaration()) continue;
 
     auto eg = EventGraph::InstructionGraph(&F);
-
-    errs() << F.getName().str() << '\n';
-
     eg->transform(GraphTransforms::CallsOnly);
 
     errs() << eg->GraphViz();

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -46,23 +46,13 @@ int main(int argc, char **argv) {
           }
         }
 
+        if(isa<EntryEvent>(e) || isa<ExitEvent>(e)) {
+          return e;
+        }
+
         return new EmptyEvent;
       }
     );
-
-    auto ent = new EntryEvent(eg, F.getName().str());
-    for(auto e : eg->entries()) {
-      if(e != ent) {
-        ent->addSuccessor(e);
-      }
-    }
-
-    auto ex = new ExitEvent(eg, F.getName().str());
-    for(auto e : eg->exits()) {
-      if(e != ex) {
-        e->addSuccessor(ex);
-      }
-    }
 
     errs() << eg->GraphViz();
   }

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -16,7 +16,13 @@ using std::queue;
 using namespace llvm;
 
 static cl::opt<std::string>
-BitcodeFilename(cl::Positional, cl::desc("bitcode"), cl::Required);
+BitcodeFilename(cl::Positional, cl::desc("<bitcode>"), cl::Required);
+
+static cl::opt<std::string>
+FunctionName(cl::Positional, cl::desc("<function>"), cl::Required);
+
+static cl::opt<int>
+UnrollDepth(cl::Positional, cl::desc("[unroll depth]"), cl::init(10));
 
 int main(int argc, char **argv) {
   SMDiagnostic Err;
@@ -30,7 +36,13 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  auto eg = EventGraph::ModuleGraph(Mod.get(), Mod->getFunction("main"));
+  auto fn = Mod->getFunction(FunctionName);
+  if(!fn) {
+    errs() << "No function named " << FunctionName << " in module " << BitcodeFilename << '\n';
+    return 2;
+  }
+
+  auto eg = EventGraph::ModuleGraph(Mod.get(), fn, UnrollDepth);
   errs() << eg->GraphViz();
 
   return 0;

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -50,6 +50,20 @@ int main(int argc, char **argv) {
       }
     );
 
+    auto ent = new EntryEvent(eg, F.getName().str());
+    for(auto e : eg->entries()) {
+      if(e != ent) {
+        ent->addSuccessor(e);
+      }
+    }
+
+    auto ex = new ExitEvent(eg, F.getName().str());
+    for(auto e : eg->exits()) {
+      if(e != ex) {
+        e->addSuccessor(ex);
+      }
+    }
+
     errs() << eg->GraphViz();
   }
 

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -30,14 +30,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  for(auto &F : *Mod) {
-    if(F.isDeclaration()) continue;
-
-    auto eg = EventGraph::InstructionGraph(&F);
-    eg->transform(GraphTransforms::CallsOnly);
-
-    errs() << eg->GraphViz();
-  }
+  auto eg = EventGraph::ModuleGraph(Mod.get(), Mod->getFunction("main"));
+  errs() << eg->GraphViz();
 
   return 0;
 }


### PR DESCRIPTION
This PR implements a tool that can extract an interprocedural event graph from a module (starting at an entry point). The events in this graph are currently only function entry and exit, but more will be added. An optional parameter for recursion unrolling depth is included.