### PR TITLE
Assert site events

### DIFF
--- a/experiments/locks/main.c
+++ b/experiments/locks/main.c
@@ -52,10 +52,10 @@ void thread_say(int id) {
 void *thread_work(void *args) {
   struct thread_args *data = (struct thread_args *)args;
 
-  TESLA_WITHIN(thread_work, strict(eventually(
+  TESLA_WITHIN(thread_work, eventually(strict(TSEQUENCE(
     acq_rel(&lock),
     returnfrom(thread_work)
-  )));
+  ))));
 
   thread_say(data->id);
 

--- a/tesla/common/Arguments.cpp
+++ b/tesla/common/Arguments.cpp
@@ -120,3 +120,43 @@ Value* tesla::GetArgumentValue(Value* Param, const Argument& ArgDescrip,
   }
   }
 }
+
+void tesla::ParseAssertionLocation(
+  Location *Loc, CallInst *Call) {
+
+  assert(Call->getCalledFunction()->getName() == INLINE_ASSERTION);
+
+  if (Call->getNumArgOperands() < 4)
+    panic("TESLA assertion must have at least 4 arguments");
+
+  // The filename (argument 1) should be a global variable.
+  GlobalVariable *NameVar =
+    dyn_cast<GlobalVariable>(Call->getOperand(1)->stripPointerCasts());
+
+  ConstantDataArray *A;
+  if (!NameVar ||
+      !(A = dyn_cast_or_null<ConstantDataArray>(NameVar->getInitializer()))) {
+    Call->dump();
+    panic("unable to parse filename from TESLA assertion");
+  }
+
+  *Loc->mutable_filename() = A->getAsString();
+
+
+  // The line and counter values should be constant integers.
+  ConstantInt *Line = dyn_cast<ConstantInt>(Call->getOperand(2));
+  if (!Line) {
+    Call->getOperand(2)->dump();
+    panic("assertion line must be a constant int");
+  }
+
+  Loc->set_line(Line->getLimitedValue(INT_MAX));
+
+  ConstantInt *Count = dyn_cast<ConstantInt>(Call->getOperand(3));
+  if (!Count) {
+    Call->getOperand(3)->dump();
+    panic("assertion count must be a constant int");
+  }
+
+  Loc->set_counter(Count->getLimitedValue(INT_MAX));
+}

--- a/tesla/common/Arguments.h
+++ b/tesla/common/Arguments.h
@@ -36,6 +36,11 @@ llvm::Value* GetArgumentValue(llvm::Value* Param, const Argument& ArgDescrip,
                               llvm::IRBuilder<>& Builder,
                               bool AtAssertionSite = false);
 
+/**
+ * Parse a @ref Location out of a @ref CallInst to the TESLA assertion
+ * pseudo-call.
+ */
+void ParseAssertionLocation(Location *Loc, llvm::CallInst*);
 }
 
 #endif

--- a/tesla/instrumenter/Assertion.cpp
+++ b/tesla/instrumenter/Assertion.cpp
@@ -143,7 +143,6 @@ bool AssertionSiteInstrumenter::ConvertAssertions(
   return true;
 }
 
-
 const Automaton* AssertionSiteInstrumenter::FindAutomaton(CallInst *Call) {
   Location Loc;
   ParseAssertionLocation(&Loc, Call);
@@ -165,47 +164,6 @@ vector<Value*> AssertionSiteInstrumenter::CollectArgs(
     Instruction *Before, const Automaton& A,
     Module& Mod, IRBuilder<>& Builder) {
   return tesla::CollectArgs(Before, A, Mod, Builder);
-}
-
-
-void AssertionSiteInstrumenter::ParseAssertionLocation(
-  Location *Loc, CallInst *Call) {
-
-  assert(Call->getCalledFunction()->getName() == INLINE_ASSERTION);
-
-  if (Call->getNumArgOperands() < 4)
-    panic("TESLA assertion must have at least 4 arguments");
-
-  // The filename (argument 1) should be a global variable.
-  GlobalVariable *NameVar =
-    dyn_cast<GlobalVariable>(Call->getOperand(1)->stripPointerCasts());
-
-  ConstantDataArray *A;
-  if (!NameVar ||
-      !(A = dyn_cast_or_null<ConstantDataArray>(NameVar->getInitializer()))) {
-    Call->dump();
-    panic("unable to parse filename from TESLA assertion");
-  }
-
-  *Loc->mutable_filename() = A->getAsString();
-
-
-  // The line and counter values should be constant integers.
-  ConstantInt *Line = dyn_cast<ConstantInt>(Call->getOperand(2));
-  if (!Line) {
-    Call->getOperand(2)->dump();
-    panic("assertion line must be a constant int");
-  }
-
-  Loc->set_line(Line->getLimitedValue(INT_MAX));
-
-  ConstantInt *Count = dyn_cast<ConstantInt>(Call->getOperand(3));
-  if (!Count) {
-    Call->getOperand(3)->dump();
-    panic("assertion count must be a constant int");
-  }
-
-  Loc->set_counter(Count->getLimitedValue(INT_MAX));
 }
 
 }

--- a/tesla/instrumenter/Assertion.h
+++ b/tesla/instrumenter/Assertion.h
@@ -80,12 +80,6 @@ private:
                                         const Automaton&, llvm::Module&,
                                         llvm::IRBuilder<>&);
 
-  /**
-   * Parse a @ref Location out of a @ref CallInst to the TESLA assertion
-   * pseudo-call.
-   */
-  static void ParseAssertionLocation(Location *Loc, llvm::CallInst*);
-
   llvm::OwningPtr<InstrContext> InstrCtx;
 
   //! The TESLA pseudo-function used to declare assertions.

--- a/tesla/model/EventGraph.cpp
+++ b/tesla/model/EventGraph.cpp
@@ -110,7 +110,6 @@ EventGraph *EventGraph::InstructionGraph(Function *f) {
 
 EventGraph *EventGraph::ModuleGraph(Module *M, Function *root, int depth) {
   auto assertFn = M->getFunction("__tesla_inline_assertion");
-  errs() << assertFn;
 
   EventGraph *eg = InstructionGraph(root);
   eg->transform(GraphTransforms::FindAssertions(assertFn));

--- a/tesla/model/EventGraph.h
+++ b/tesla/model/EventGraph.h
@@ -213,16 +213,11 @@ struct ExitEvent : public Event {
 };
 
 struct AssertEvent : public Event {
-  AssertEvent(EventGraph *g, string file, int line, int count) :
-    Event(EV_Assert, g), loc(new tesla::Location)
-  {
-    loc->set_filename(file);
-    loc->set_line(line);
-    loc->set_counter(count);
-  }
+  AssertEvent(EventGraph *g, tesla::Location *l) :
+    Event(EV_Assert, g), loc(l) {}
 
-  AssertEvent(string file, int line, int count) :
-    AssertEvent(nullptr, file, line, count) {}
+  AssertEvent(tesla::Location *l) :
+    AssertEvent(nullptr, l) {}
 
   const tesla::Location &Location() const { return *loc; }
 

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -1,3 +1,5 @@
+#include "Arguments.h"
+
 #include "GraphTransforms.h"
 
 Event *GraphTransforms::FindAssertions::operator()(Event *e) {
@@ -8,6 +10,8 @@ Event *GraphTransforms::FindAssertions::operator()(Event *e) {
   auto ie = cast<InstructionEvent>(e);
   if(auto ci = dyn_cast<CallInst>(ie->Instr())) {
     if(ci->getCalledFunction() == Assertion) {
+      auto loc = new tesla::Location;
+      tesla::ParseAssertionLocation(loc, ci);
       return new AssertEvent("some file", 57, 27);
     }
   }

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -12,7 +12,8 @@ Event *GraphTransforms::FindAssertions::operator()(Event *e) {
     if(ci->getCalledFunction() == Assertion) {
       auto loc = new tesla::Location;
       tesla::ParseAssertionLocation(loc, ci);
-      return new AssertEvent("some file", 57, 27);
+
+      return new AssertEvent(loc);
     }
   }
 

--- a/tesla/model/GraphTransforms.cpp
+++ b/tesla/model/GraphTransforms.cpp
@@ -1,5 +1,20 @@
 #include "GraphTransforms.h"
 
+Event *GraphTransforms::FindAssertions::operator()(Event *e) {
+  if(isa<EntryEvent>(e) || isa<ExitEvent>(e)) {
+    return e;
+  }
+
+  auto ie = cast<InstructionEvent>(e);
+  if(auto ci = dyn_cast<CallInst>(ie->Instr())) {
+    if(ci->getCalledFunction() == Assertion) {
+      return new AssertEvent("some file", 57, 27);
+    }
+  }
+
+  return e;
+}
+
 Event *GraphTransforms::CallsOnly(Event *e) {
   if(auto ie = dyn_cast<InstructionEvent>(e)) {
     if(auto ci = dyn_cast<CallInst>(ie->Instr())) {
@@ -12,7 +27,7 @@ Event *GraphTransforms::CallsOnly(Event *e) {
     return new EmptyEvent;
   }
 
-  if(isa<EntryEvent>(e) || isa<ExitEvent>(e)) {
+  if(isa<EntryEvent>(e) || isa<ExitEvent>(e) || isa<AssertEvent>(e)) {
     return e;
   }
 

--- a/tesla/model/GraphTransforms.h
+++ b/tesla/model/GraphTransforms.h
@@ -6,9 +6,20 @@
 namespace GraphTransforms {
 
 Event *CallsOnly(Event *e);
+
 Event *DeleteCalls(Event *e);
 
-struct Tag{
+struct FindAssertions {
+  FindAssertions(Function *a) :
+    Assertion(a) {}
+
+  Event *operator()(Event *e);
+
+private:
+  Function *Assertion;
+};
+
+struct Tag {
   Tag(Event *e, string s) :
     ev(e), str_(s) {}
 


### PR DESCRIPTION
Add assertion site events to the extracted module graph, with locations parsed using the same mechanism as the assertion site instrumenter uses.