### PR TITLE
Correct complete

### DIFF
--- a/tesla/model/ModelChecker.h
+++ b/tesla/model/ModelChecker.h
@@ -42,6 +42,7 @@ struct CheckResult {
 
     return ss.str();
   }
+
 private:
   size_t Length_;
   bool Successful_;
@@ -60,16 +61,16 @@ struct ModelChecker {
 
   void MarkIgnoredEvents(const tesla::Expression &ex, TaggedTrace &tr);
 
-  CheckResult CheckState(const tesla::Expression &ex, TaggedTrace, int);
-  CheckResult CheckBoolean(const tesla::BooleanExpr &ex, TaggedTrace, int);
-  CheckResult CheckSequence(const tesla::Sequence &ex, TaggedTrace, int);
-  CheckResult CheckSequenceOnce(const tesla::Sequence &ex, TaggedTrace, int, 
+  CheckResult CheckState(const tesla::Expression &ex, TaggedTrace &, int);
+  CheckResult CheckBoolean(const tesla::BooleanExpr &ex, TaggedTrace &, int);
+  CheckResult CheckSequence(const tesla::Sequence &ex, TaggedTrace &, int);
+  CheckResult CheckSequenceOnce(const tesla::Sequence &ex, TaggedTrace &, int, 
                                 set<const tesla::Expression *> = {});
-  CheckResult CheckNull(TaggedTrace, int);
-  CheckResult CheckAssertionSite(const tesla::AssertionSite &ex, TaggedTrace, int);
-  CheckResult CheckFunction(const tesla::FunctionEvent &ex, TaggedTrace, int);
-  CheckResult CheckFieldAssign(const tesla::FieldAssignment &ex, TaggedTrace, int);
-  CheckResult CheckSubAutomaton(const tesla::Automaton &ex, TaggedTrace, int);
+  CheckResult CheckNull(TaggedTrace &, int);
+  CheckResult CheckAssertionSite(const tesla::AssertionSite &ex, TaggedTrace &, int);
+  CheckResult CheckFunction(const tesla::FunctionEvent &ex, TaggedTrace &, int);
+  CheckResult CheckFieldAssign(const tesla::FieldAssignment &ex, TaggedTrace &, int);
+  CheckResult CheckSubAutomaton(const tesla::Automaton &ex, TaggedTrace &, int);
 
   static TaggedTrace tagged(const FiniteTraces::Trace);
 

--- a/tesla/model/ModelChecker.h
+++ b/tesla/model/ModelChecker.h
@@ -58,6 +58,8 @@ struct ModelChecker {
 
   set<const tesla::Usage *> SafeUsages();
 
+  void MarkIgnoredEvents(const tesla::Expression &ex, TaggedTrace &tr);
+
   CheckResult CheckState(const tesla::Expression &ex, TaggedTrace, int);
   CheckResult CheckBoolean(const tesla::BooleanExpr &ex, TaggedTrace, int);
   CheckResult CheckSequence(const tesla::Sequence &ex, TaggedTrace, int);

--- a/tesla/model/ModelChecker.h
+++ b/tesla/model/ModelChecker.h
@@ -6,11 +6,14 @@
 
 #include <set>
 #include <sstream>
+#include <vector>
 
 #include "EventGraph.h"
 #include "FiniteTraces.h"
 
+using std::pair;
 using std::set;
+using std::vector;
 using namespace llvm;
 
 struct CheckResult {
@@ -48,23 +51,25 @@ private:
 };
 
 struct ModelChecker {
+  using TaggedTrace = vector<pair<Event *, bool>>;
+
   ModelChecker(EventGraph *gr, Module *mod, tesla::Manifest *man) :
     Graph(gr), Mod(mod), Manifest(man) {}
 
   set<const tesla::Usage *> SafeUsages();
 
-  CheckResult CheckState(const tesla::Expression &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckState(const tesla::Expression &ex, const FiniteTraces::Trace &, size_t);
-  CheckResult CheckBoolean(const tesla::BooleanExpr &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckSequence(const tesla::Sequence &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckSequenceOnce(const tesla::Sequence &ex, const FiniteTraces::Trace &, int, 
+  CheckResult CheckState(const tesla::Expression &ex, TaggedTrace, int);
+  CheckResult CheckBoolean(const tesla::BooleanExpr &ex, TaggedTrace, int);
+  CheckResult CheckSequence(const tesla::Sequence &ex, TaggedTrace, int);
+  CheckResult CheckSequenceOnce(const tesla::Sequence &ex, TaggedTrace, int, 
                                 set<const tesla::Expression *> = {});
-  CheckResult CheckNull(const FiniteTraces::Trace &, int);
-  CheckResult CheckAssertionSite(const tesla::AssertionSite &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckFunction(const tesla::FunctionEvent &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckFieldAssign(const tesla::FieldAssignment &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckSubAutomaton(const tesla::Automaton &ex, const FiniteTraces::Trace &, int);
-  CheckResult CheckSubAutomaton(const tesla::Automaton &ex, const FiniteTraces::Trace &, size_t);
+  CheckResult CheckNull(TaggedTrace, int);
+  CheckResult CheckAssertionSite(const tesla::AssertionSite &ex, TaggedTrace, int);
+  CheckResult CheckFunction(const tesla::FunctionEvent &ex, TaggedTrace, int);
+  CheckResult CheckFieldAssign(const tesla::FieldAssignment &ex, TaggedTrace, int);
+  CheckResult CheckSubAutomaton(const tesla::Automaton &ex, TaggedTrace, int);
+
+  static TaggedTrace tagged(const FiniteTraces::Trace);
 
   EventGraph *Graph;
   Module *Mod;


### PR DESCRIPTION
This improves the model checking algorithm so that assertions are checked to be both *correct* and *complete* (the sequence of events matches the assertion, and no event that could be matched by the assertion is not matched).

With these improvements, the simpler example programs from the `acq_rel` stuff can be checked correctly for safety using the model checker.