### PR TITLE
Tesla server

### DIFF
--- a/experiments/server/CMakeLists.txt
+++ b/experiments/server/CMakeLists.txt
@@ -11,5 +11,11 @@ set(CLIENT_SRCS
   protocol.c
 )
 
+option(SERVER_USE_TESLA ON)
+
+if(SERVER_USE_TESLA)
+  set(CMAKE_C_FLAGS "-DUSE_TESLA ${CMAKE_C_FLAGS}")
+endif()
+
 add_tesla_executable("${SERVER_SRCS}" server TRUE)
 add_tesla_executable("${CLIENT_SRCS}" client TRUE)

--- a/experiments/server/server_handler.c
+++ b/experiments/server/server_handler.c
@@ -18,7 +18,7 @@ void unlock_file() { pthread_mutex_unlock(&lock); }
 
 void *write_to_fd(void *data);
 
-#define HANDLER() \
+#define tesla_handle_only() \
   TESLA_WITHIN(write_to_fd, TSEQUENCE( \
     call(handle_connection), \
     TESLA_ASSERTION_SITE, \
@@ -28,6 +28,17 @@ void *write_to_fd(void *data);
 #endif
 
 void handle_connection(int fd) {
+  TESLA_WITHIN(write_to_fd,
+    TSEQUENCE(
+      TESLA_ASSERTION_SITE,
+      ATLEAST(1, TSEQUENCE(
+        call(lock_file),
+        call(unlock_file)
+      )),
+      returnfrom(handle_connection)
+    )
+  );
+
   printf("Starting connection [%d]\n", fd);
 
   state *st = calloc(1, sizeof(*st));
@@ -41,6 +52,19 @@ void handle_connection(int fd) {
 }
 
 void expect_request(state *st) {
+  tesla_handle_only();
+
+  TESLA_WITHIN(write_to_fd,
+    TSEQUENCE(
+      call(expect_request),
+      TESLA_ASSERTION_SITE,
+      TSEQUENCE(
+        call(expect_data)
+      ) || call(error),
+      returnfrom(expect_request)
+    )
+  );
+
   struct packet p = next_packet(st->socket);
 
   if(p.kind == PK_REQUEST) {
@@ -61,6 +85,8 @@ void expect_request(state *st) {
 }
 
 void expect_data(state *st) {
+  tesla_handle_only();
+
   for(uint16_t i = 0; i < st->n_packets; i++) {
     struct packet p = next_packet(st->socket);
 
@@ -97,6 +123,8 @@ void expect_data(state *st) {
 }
 
 void expect_done(state *st) {
+  tesla_handle_only();
+
   struct packet p = next_packet(st->socket);
 
   if(p.kind == PK_DONE) {
@@ -107,6 +135,8 @@ void expect_done(state *st) {
 }
 
 void success(state *st) {
+  tesla_handle_only();
+
   struct packet done = {
     .kind = PK_DONE,
     .seq_no = 0,
@@ -118,6 +148,8 @@ void success(state *st) {
 }
 
 void error(state *st, char *message) {
+  tesla_handle_only();
+
   fprintf(stderr, "Server thread exiting with error: %s\n", message);
   pthread_exit(0);
 }


### PR DESCRIPTION
This PR adds TESLA assertions to the simple client-server application developed previously. The assertions perform simple validation that the server embedding is being used properly (i.e. that handler methods aren't being called from outside of the main handler method, which would break the state of the server thread).

Preliminary benchmarking seems to indicate that there is about a 5% performance penalty from using the TESLA assertions (independent of the number of concurrent connections).