### PR TITLE
Implement cyclic checking

### DIFF
--- a/tesla/model/include/ModelChecker.h
+++ b/tesla/model/include/ModelChecker.h
@@ -27,7 +27,7 @@ struct ModelChecker {
   set<const tesla::Usage *> SafeUsages();
 
 private:
-  bool CheckAgainst(const FiniteTraces::Trace &tr, const ModelGenerator::Model &mod);
+  bool CheckAgainst(const FiniteTraces::Trace &tr, const ModelGenerator::Model &mod, bool cycle=false);
 
   bool CheckState(const tesla::Expression &ex, Event *);
   bool CheckAssertionSite(const tesla::AssertionSite &ex, Event *);


### PR DESCRIPTION
This allows the model checker to validate cyclic traces (by a prefix mechanism rather than exact matching).