### PR TITLE
Rename Branch to BoolValue

### DIFF
--- a/tesla/model/include/ImplicationCheck.h
+++ b/tesla/model/include/ImplicationCheck.h
@@ -17,12 +17,12 @@ namespace Implication {
  *    and checking on all the possible valuations generated (i.e. set b to false
  *    and check that every valuation then evals to false as well).
  */
-bool Check(Condition *c, Branch b);
+bool Check(Condition *c, BoolValue b);
 
 /**
  * Generate the set of all implied branches for a particular condition.
  */
-std::set<Branch> BranchesFrom(Condition *c);
+std::set<BoolValue> BoolValuesFrom(Condition *c);
 
 }
 

--- a/tesla/model/lib/ImplicationCheck.cpp
+++ b/tesla/model/lib/ImplicationCheck.cpp
@@ -1,12 +1,12 @@
 #include "ImplicationCheck.h"
 
-bool Implication::Check(Condition *c, Branch b) {
+bool Implication::Check(Condition *c, BoolValue b) {
   auto not_b = *b.Negated();
 
-  auto allBranches = c->Branches();
-  std::set<Branch> extras;
+  auto allBoolValues = c->BoolValues();
+  std::set<BoolValue> extras;
 
-  for(auto e : allBranches) {
+  for(auto e : allBoolValues) {
     if ((e != b) && (e != not_b)) {
       extras.insert(e);
     }
@@ -33,10 +33,10 @@ bool Implication::Check(Condition *c, Branch b) {
   );
 }
 
-std::set<Branch> Implication::BranchesFrom(Condition *c) {
-  std::set<Branch> ret;
+std::set<BoolValue> Implication::BoolValuesFrom(Condition *c) {
+  std::set<BoolValue> ret;
 
-  for(auto branch : c->Branches()) {
+  for(auto branch : c->BoolValues()) {
     if(Implication::Check(c, branch)) {
       ret.insert(branch);
     }

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
       errs() << "--------------------\n\n";
       errs() << "###\tconds: " << pair.second->str() << "\t###\n";
 
-      for(auto b : Implication::BranchesFrom(pair.second)) {
+      for(auto b : Implication::BoolValuesFrom(pair.second)) {
         errs() << "\t" << "implies " << b.str() << '\n';
       }
 


### PR DESCRIPTION
This more accurately reflects that these objects constrain an LLVM value
to be a boolean, rather than being restricted to just a branch
condition.