### PR TITLE
Implement very basic backwards inference of call results

### DIFF
--- a/tesla/model/include/BackwardsSearch.h
+++ b/tesla/model/include/BackwardsSearch.h
@@ -1,0 +1,18 @@
+#ifndef BACKWARDS_SEARCH_H
+#define BACKWARDS_SEARCH_H
+
+#include "Inference.h"
+
+namespace BackwardsSearch {
+
+// Search backwards from the given BoolValue, trying to resolve any data
+// dependencies we know how to along the way. Stops when a CallInst is found,
+// and returns nullptr if we hit an unresolvable point in the search.
+BoolValue *From(BoolValue b);
+
+// Try to resolve the given BoolValue into a "next step".
+BoolValue *Resolve(BoolValue b);
+
+}
+
+#endif

--- a/tesla/model/include/Inference.h
+++ b/tesla/model/include/Inference.h
@@ -109,6 +109,9 @@ struct BoolValue : public Condition {
 
   BoolValue *Negated() const { return new BoolValue{value, !constraint}; }
 
+  Value *const GetValue() const { return value; }
+  bool GetConstraint() const { return constraint; }
+
   virtual Condition *Simplified() const override;
   std::set<BoolValue> BoolValues() const override { return {*this}; }
   virtual bool IsConstant() const override { return false; }

--- a/tesla/model/lib/BackwardsSearch.cpp
+++ b/tesla/model/lib/BackwardsSearch.cpp
@@ -1,0 +1,50 @@
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Instructions.h>
+
+#include "BackwardsSearch.h"
+
+using namespace llvm;
+
+BoolValue *BackwardsSearch::From(BoolValue b) {
+  auto next = &b;
+
+  do {
+    if(isa<CallInst>(next->GetValue())) {
+      return next;
+    }
+  } while((next = Resolve(*next)));
+
+  return nullptr;
+}
+
+BoolValue *BackwardsSearch::Resolve(BoolValue b) {
+  auto bop = dyn_cast<BinaryOperator>(b.GetValue());
+  if(!bop) {
+    return nullptr;
+  }
+
+  ConstantInt *constArg = nullptr;
+  Value *otherArg = nullptr;
+
+  for(auto i = 0; i < bop->getNumOperands(); i++) {
+    auto operand = bop->getOperand(i);
+
+    if(auto constOper = dyn_cast<ConstantInt>(operand)) {
+      constArg = constOper;
+      otherArg = bop->getOperand(1-i);
+    }
+  }
+
+  if(!constArg) {
+    return nullptr;
+  }
+
+  auto constVal = constArg->getValue().getBoolValue();
+
+  switch(bop->getOpcode()) {
+    case Instruction::Xor:
+      return new BoolValue{otherArg, constVal != b.GetConstraint()};
+    default:
+      assert(false && "Unhandled op type for resolution!");
+  }
+}

--- a/tesla/model/lib/CMakeLists.txt
+++ b/tesla/model/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_llvm_library(TeslaModel
   ModelGenerator.cpp
   Inference.cpp
   ImplicationCheck.cpp
+  BackwardsSearch.cpp
 )
 
 target_link_libraries(TeslaModel

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <queue>
 
+#include "BackwardsSearch.h"
 #include "Debug.h"
 #include "EventGraph.h"
 #include "FiniteTraces.h"
@@ -76,6 +77,10 @@ int main(int argc, char **argv) {
 
       for(auto b : Implication::BoolValuesFrom(pair.second)) {
         errs() << "\t" << "implies " << b.str() << '\n';
+        if(auto then = BackwardsSearch::From(b)) {
+          errs() << "\t and then " << then->str() << '\n';
+          then->GetValue()->dump();
+        }
       }
 
       pair.first->print(errs());


### PR DESCRIPTION
This handles a very simple case of this inference only, but the idea could very well be extended to allow for more sophisticated decision procedures in a similar vein.