### PR TITLE
Improve the strongest inference interface

### DIFF
--- a/tesla/model/include/Inference.h
+++ b/tesla/model/include/Inference.h
@@ -54,7 +54,7 @@ public:
   virtual std::string str() const = 0;
   virtual bool Equal(Condition *other) const = 0;
 
-  static std::map<BasicBlock *, Condition *> StrongestInferences(Function *f);
+  static std::map<BasicBlock *, std::set<BoolValue *>> StrongestInferences(Function *f);
   static Condition *BranchCondition(BasicBlock *pred, BasicBlock *succ);
 };
 

--- a/tesla/model/model.cpp
+++ b/tesla/model/model.cpp
@@ -73,14 +73,8 @@ int main(int argc, char **argv) {
     auto infs = Condition::StrongestInferences(&f);
     for(auto pair : infs) {
       errs() << "--------------------\n\n";
-      errs() << "###\tconds: " << pair.second->str() << "\t###\n";
-
-      for(auto b : Implication::BoolValuesFrom(pair.second)) {
-        errs() << "\t" << "implies " << b.str() << '\n';
-        if(auto then = BackwardsSearch::From(b)) {
-          errs() << "\t and then " << then->str() << '\n';
-          then->GetValue()->dump();
-        }
+      for(auto b : pair.second) {
+        errs() << "\t" << "implies " << b->str() << '\n';
       }
 
       pair.first->print(errs());


### PR DESCRIPTION
Backwards search and implication checking are now exposed only by the strongest inference check, rather than as separate components.