### PR TITLE
Check return constraints

### DIFF
--- a/tesla/model/include/EventGraph.h
+++ b/tesla/model/include/EventGraph.h
@@ -197,7 +197,7 @@ struct EntryEvent : public Event {
   CallInst *Call;
 
   virtual string Name() const override {
-    return "enter:" + Description + (Call ? " (called)" : "");
+    return "enter:" + Description + (Call ? "" : " (no call)");
   }
 
   static bool classof(const Event *other) {
@@ -226,7 +226,7 @@ struct ExitEvent : public Event {
   CallInst *Call;
 
   virtual string Name() const override {
-    return "exit:" + Description + (Call ? " (called)" : "");
+    return "exit:" + Description + (Call ? "" : " (no call)");
   }
 
   static bool classof(const Event *other) {

--- a/tesla/model/include/EventGraph.h
+++ b/tesla/model/include/EventGraph.h
@@ -56,6 +56,7 @@ struct EventGraph {
 
   set<Event *> entries();
   set<Event *> exits();
+  const set<Event *>& getEvents() const { return Events; }
 
   EventRange *ReleasedRange();
 

--- a/tesla/model/include/EventGraph.h
+++ b/tesla/model/include/EventGraph.h
@@ -184,7 +184,7 @@ struct EntryEvent : public Event {
     : Event(EV_Enter, g), Description(f->getName().str()), Func(f), Call(nullptr) {}
 
   EntryEvent(EventGraph *g, CallInst *ci)
-    : Event(EV_Exit, g), 
+    : Event(EV_Enter, g),
       Description(ci->getCalledFunction()->getName().str()), 
       Func(ci->getCalledFunction()), 
       Call(ci) {}

--- a/tesla/model/include/EventGraph.h
+++ b/tesla/model/include/EventGraph.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <vector>
 
+#include "Inference.h"
 #include "Names.h"
 #include "tesla.pb.h"
 
@@ -164,11 +165,17 @@ struct EmptyEvent : public Event {
 };
 
 struct BasicBlockEvent : public Event {
-  BasicBlockEvent(EventGraph *g, BasicBlock *bb)
-    : Event(EV_BasicBlock, g), Block(bb) {}
+  BasicBlockEvent(EventGraph *g, BasicBlock *bb, std::set<BoolValue *> infs)
+    : Event(EV_BasicBlock, g), Block(bb), Inferences(infs) {}
+
+  BasicBlockEvent(EventGraph *eg, BasicBlock *bb)
+    : BasicBlockEvent(eg, bb, {}) {}
 
   BasicBlockEvent(BasicBlock *bb)
-    : BasicBlockEvent(nullptr, bb) {}
+    : BasicBlockEvent(nullptr, bb, {}) {}
+
+  BasicBlockEvent(BasicBlock *bb, std::set<BoolValue *> infs)
+    : BasicBlockEvent(nullptr, bb, infs) {}
 
   virtual string Name() const override {
     std::stringstream ss;
@@ -181,6 +188,7 @@ struct BasicBlockEvent : public Event {
   }
 
   BasicBlock *Block;
+  std::set<BoolValue *> Inferences;
 };
 
 struct EntryEvent : public Event {

--- a/tesla/model/include/EventGraph.h
+++ b/tesla/model/include/EventGraph.h
@@ -19,10 +19,12 @@
 #include "Names.h"
 #include "tesla.pb.h"
 
+using std::map;
 using std::set;
 using std::string;
 using namespace llvm;
 
+struct BasicBlockEvent;
 struct Event;
 struct EventRange;
 
@@ -43,6 +45,11 @@ struct EventGraph {
   void transform(EventTransformation T);
 
   static EventGraph *BasicBlockGraph(Function *f);
+
+  static EventRange *Expand(BasicBlockEvent *e, int depth, map<Function *, EventGraph *>& cache);
+  static EventGraph *ExpandedBasicBlockGraph(Function *f, int depth);
+  static EventGraph *ExpandedBasicBlockGraph(Function *f, int depth, map<Function *, EventGraph *>& cache);
+
   static EventGraph *InstructionGraph(Function *f, CallInst *ci=nullptr);
   static EventGraph *ModuleGraph(Module *M, Function *root, int depth);
 

--- a/tesla/model/include/FiniteTraces.h
+++ b/tesla/model/include/FiniteTraces.h
@@ -19,7 +19,10 @@ struct FiniteTraces {
   using TraceSet = set<Trace>;
 
   FiniteTraces(EventGraph *eg) :
-    Graph(eg) {}
+    Graph(eg), Root(nullptr) {}
+
+  FiniteTraces(EventGraph *eg, Event *root) :
+    Graph(eg), Root(root) {}
 
   TraceSet OfLength(size_t len);
   TraceSet OfLengthUpTo(size_t len);
@@ -32,6 +35,7 @@ struct FiniteTraces {
 private:
   map<size_t, TraceSet> cache;
   EventGraph *Graph;
+  Event *Root;
 };
 
 #endif

--- a/tesla/model/include/GraphTransforms.h
+++ b/tesla/model/include/GraphTransforms.h
@@ -30,6 +30,8 @@ private:
   string str_;
 };
 
+Event *DeleteEntryExit(Event *e);
+
 }
 
 #endif

--- a/tesla/model/include/ModelChecker.h
+++ b/tesla/model/include/ModelChecker.h
@@ -21,7 +21,8 @@ using namespace llvm;
 
 struct ModelChecker {
   ModelChecker(EventGraph *gr, Module *mod, tesla::Manifest *man, Function *bound, int d) :
-    Graph(gr), Mod(mod), Manifest(man), Bound(bound), Depth(d) {}
+    Graph(gr), BBGraph(EventGraph::ExpandedBasicBlockGraph(bound, d)), Mod(mod), 
+    Manifest(man), Bound(bound), Depth(d) {}
 
   bool IsUsageSafe(const tesla::Usage *use);
   set<const tesla::Usage *> SafeUsages();
@@ -32,6 +33,7 @@ private:
   static bool hasReturnConstraint(Expression *e);
   static int getReturnConstraint(Expression *e);
   bool CheckReturnValues(const FiniteTraces::Trace &tr, const ModelGenerator::Model &mod);
+  bool ReturnConstraintSearch(std::vector<BoolValue> &constraints, int index, Event *root);
 
   bool CheckState(const tesla::Expression &ex, Event *);
   bool CheckAssertionSite(const tesla::AssertionSite &ex, Event *);
@@ -40,6 +42,7 @@ private:
   FiniteTraces::Trace filteredTrace(const FiniteTraces::Trace &tr, const tesla::Expression ex);
 
   EventGraph *Graph;
+  EventGraph *BBGraph;
   Module *Mod;
   tesla::Manifest *Manifest;
   Function *Bound;

--- a/tesla/model/include/ModelChecker.h
+++ b/tesla/model/include/ModelChecker.h
@@ -29,6 +29,10 @@ struct ModelChecker {
 private:
   bool CheckAgainst(const FiniteTraces::Trace &tr, const ModelGenerator::Model &mod, bool cycle=false);
 
+  static bool hasReturnConstraint(Expression *e);
+  static int getReturnConstraint(Expression *e);
+  bool CheckReturnValues(const FiniteTraces::Trace &tr, const ModelGenerator::Model &mod);
+
   bool CheckState(const tesla::Expression &ex, Event *);
   bool CheckAssertionSite(const tesla::AssertionSite &ex, Event *);
   bool CheckFunction(const tesla::FunctionEvent &ex, Event *);

--- a/tesla/model/lib/EventGraph.cpp
+++ b/tesla/model/lib/EventGraph.cpp
@@ -76,7 +76,11 @@ EventGraph *EventGraph::BasicBlockGraph(Function *f) {
   return eg;
 }
 
-EventGraph *EventGraph::InstructionGraph(Function *f) {
+EventGraph *EventGraph::InstructionGraph(Function *f, CallInst *ci) {
+  if(ci) {
+    assert(f == ci->getCalledFunction() && "Heading for inconsistency here");
+  }
+
   auto eg = BasicBlockGraph(f);
 
   set<BasicBlockEvent *> toRemove;
@@ -91,14 +95,14 @@ EventGraph *EventGraph::InstructionGraph(Function *f) {
     eg->replace(bbe, range);
   }
 
-  auto ent = new EntryEvent(eg, f);
+  auto ent = ci ? new EntryEvent(eg, ci) : new EntryEvent(eg, f);
   for(auto e : eg->entries()) {
     if(e != ent) {
       ent->addSuccessor(e);
     }
   }
 
-  auto ex = new ExitEvent(eg, f);
+  auto ex = ci ? new ExitEvent(eg, ci) : new ExitEvent(eg, f);
   for(auto e : eg->exits()) {
     if(e != ex) {
       e->addSuccessor(ex);

--- a/tesla/model/lib/EventGraph.cpp
+++ b/tesla/model/lib/EventGraph.cpp
@@ -50,6 +50,8 @@ void EventGraph::assert_valid() {
 EventGraph *EventGraph::BasicBlockGraph(Function *f) {
   auto eg = new EventGraph(f->getName().str());
 
+  auto infs = Condition::StrongestInferences(f);
+
   map<BasicBlock *, Event *> cache;
 
   for(auto &BB : *f) {
@@ -59,14 +61,14 @@ EventGraph *EventGraph::BasicBlockGraph(Function *f) {
        &BB != &f->getEntryBlock()) { continue; }
 
     if(cache.find(&BB) == cache.end()) {
-      cache[&BB] = new BasicBlockEvent(eg, &BB);
+      cache[&BB] = new BasicBlockEvent(eg, &BB, infs[&BB]);
     }
 
     auto term = BB.getTerminator();
     for(int i = 0; i < term->getNumSuccessors(); i++) {
       auto suc = term->getSuccessor(i);
       if(cache.find(suc) == cache.end()) {
-        cache[suc] = new BasicBlockEvent(eg, suc);
+        cache[suc] = new BasicBlockEvent(eg, suc, infs[suc]);
       }
 
       cache[&BB]->successors.insert(cache[suc]);

--- a/tesla/model/lib/EventGraph.cpp
+++ b/tesla/model/lib/EventGraph.cpp
@@ -125,7 +125,7 @@ EventGraph *EventGraph::ModuleGraph(Module *M, Function *root, int depth) {
       if(auto ce = dyn_cast<CallEvent>(ev)) {
         auto fn = ce->Call()->getCalledFunction();
 
-        auto gr = InstructionGraph(fn);
+        auto gr = InstructionGraph(fn, ce->Call());
         gr->transform(GraphTransforms::FindAssertions(assertFn));
         gr->transform(GraphTransforms::CallsOnly);
 

--- a/tesla/model/lib/FiniteTraces.cpp
+++ b/tesla/model/lib/FiniteTraces.cpp
@@ -17,13 +17,17 @@ FiniteTraces::TraceSet FiniteTraces::OfLength(size_t len) {
 
   // Traces of length 1 are just the entries to the graph
   if(len == 1) {
-    set<Trace> entries;
-    for(auto e : Graph->entries()) {
-      entries.insert({e});
-    }
+    if(!Root) {
+      set<Trace> entries;
+      for(auto e : Graph->entries()) {
+        entries.insert({e});
+      }
 
-    cache[1] = entries;
-    return entries;
+      cache[1] = entries;
+      return entries;
+    } else {
+      return {{Root}};
+    }
   }
 
   auto preds = OfLength(len - 1);

--- a/tesla/model/lib/GraphTransforms.cpp
+++ b/tesla/model/lib/GraphTransforms.cpp
@@ -60,3 +60,11 @@ Event *GraphTransforms::Tag::operator()(Event *e) {
 
   return e;
 }
+
+Event *GraphTransforms::DeleteEntryExit(Event *e) {
+  if(isa<EntryEvent>(e) || isa<ExitEvent>(e)) {
+    return new EmptyEvent;
+  }
+
+  return e;
+}

--- a/tesla/model/lib/ModelChecker.cpp
+++ b/tesla/model/lib/ModelChecker.cpp
@@ -48,6 +48,9 @@ bool ModelChecker::IsUsageSafe(const tesla::Usage *use) {
 }
 
 set<const tesla::Usage *> ModelChecker::SafeUsages() {
+  auto ebbg = EventGraph::ExpandedBasicBlockGraph(Bound, Depth);
+  errs() << ebbg->GraphViz();
+
   set<const tesla::Usage *> safeUses;
 
   for(auto use : Manifest->RootAutomata()) {

--- a/tesla/model/lib/ModelChecker.cpp
+++ b/tesla/model/lib/ModelChecker.cpp
@@ -111,14 +111,12 @@ bool ModelChecker::CheckReturnValues(const FiniteTraces::Trace &tr, const ModelG
   auto constraints = std::vector<BoolValue>{};
   for(auto i = 0; i < tr.size(); i++) {
     if(auto exe = dyn_cast<ExitEvent>(tr[i])) {
-      if(hasReturnConstraint(mod[i])) {
+      if(exe->Call && hasReturnConstraint(mod[i])) {
         constraints.push_back(
-            BoolValue{exe->Func, static_cast<bool>(getReturnConstraint(mod[i]))});
+            BoolValue{exe->Call, static_cast<bool>(getReturnConstraint(mod[i]))});
       }
     }
   }
-
-  errs() << Graph->GraphViz() << '\n';
 
   return true;
 }


### PR DESCRIPTION
This PR implements a mechanism for checking return value constraints generated by a TESLA model. The algorithm used is quite slow - future work would improve the rather naive graph search mechanism used to find a possible trace.

Despite the slow performance, this is the final improvement needed to make the model checker "feature complete" with respect to the hand-coded acq-rel passes.