### PR TITLE
Parallelise model checker

### DIFF
--- a/tesla/model/include/FiniteTraces.h
+++ b/tesla/model/include/FiniteTraces.h
@@ -4,6 +4,7 @@
 #include <llvm/IR/Function.h>
 
 #include <map>
+#include <mutex>
 #include <set>
 #include <vector>
 
@@ -36,6 +37,7 @@ private:
   map<size_t, TraceSet> cache;
   EventGraph *Graph;
   Event *Root;
+  std::mutex cache_lock;
 };
 
 #endif


### PR DESCRIPTION
This PR parcels out the parallelisable work of the model checker to as many hardware threads as possible - each one generates and checks for counterexamples at a single depth value. All the threads will stop as soon as a single counterexample is found.