### PR TITLE
Fix some crashes in the event graph builder

### DIFF
--- a/cmake/Tesla.cmake
+++ b/cmake/Tesla.cmake
@@ -75,7 +75,7 @@ function(add_tesla_executable C_SOURCES EXE_NAME STATIC)
   if(STATIC AND CMAKE_USE_STATIC)
     add_custom_command(
       OUTPUT ${EXE_NAME}.static.manifest
-      COMMAND tesla static ${EXE_NAME}.manifest ${EXE_NAME}.bc -o ${EXE_NAME}.static.manifest
+      COMMAND tesla static ${EXE_NAME}.manifest ${EXE_NAME}.bc -modelcheck -bound=1000 -o ${EXE_NAME}.static.manifest
       DEPENDS ${EXE_NAME}.manifest ${EXE_NAME}.bc
     )
     add_custom_target(${EXE_NAME}-static-manifest

--- a/tesla/model/lib/EventGraph.cpp
+++ b/tesla/model/lib/EventGraph.cpp
@@ -87,7 +87,7 @@ EventRange *EventGraph::Expand(BasicBlockEvent *e, int depth, map<Function *, Ev
   EventRange *range = nullptr;
   for(auto& I : *e->Block) {
     if(auto ci = dyn_cast<CallInst>(&I)) {
-      if(ci->getCalledFunction()->isDeclaration()) {
+      if(!ci->getCalledFunction() || ci->getCalledFunction()->isDeclaration()) {
         continue;
       }
 


### PR DESCRIPTION
There were some null pointer derefs in the case where a call to a function pointer was made - this PR fixes the issue so that function pointer calls are just ignored.