### PR TITLE
Fix all warnings generated when building

### DIFF
--- a/tesla/instrumenter/Caller.cpp
+++ b/tesla/instrumenter/Caller.cpp
@@ -226,6 +226,7 @@ CallerInstrumentation*
                                  bool SuppressDebugInstr) {
 
   assert(false && "update ObjC implementation");
+  __builtin_unreachable();
 }
 
 

--- a/tesla/model/lib/BackwardsSearch.cpp
+++ b/tesla/model/lib/BackwardsSearch.cpp
@@ -45,6 +45,6 @@ BoolValue *BackwardsSearch::Resolve(BoolValue b) {
     case Instruction::Xor:
       return new BoolValue{otherArg, constVal != b.GetConstraint()};
     default:
-      assert(false && "Unhandled op type for resolution!");
+      return nullptr;
   }
 }

--- a/tesla/model/lib/GraphTransforms.cpp
+++ b/tesla/model/lib/GraphTransforms.cpp
@@ -37,6 +37,7 @@ Event *GraphTransforms::CallsOnly(Event *e) {
   }
 
   assert(false && "Non instruction event in calls only transform");
+  __builtin_unreachable();
 }
 
 Event *GraphTransforms::DeleteCalls(Event *e) {

--- a/tesla/model/lib/Inference.cpp
+++ b/tesla/model/lib/Inference.cpp
@@ -32,6 +32,7 @@ Condition *Condition::BranchCondition(BasicBlock *pred, BasicBlock *succ) {
   }
 
   assert(false && "Successor not actually a successor");
+  __builtin_unreachable();
 }
 
 std::map<BasicBlock *, std::set<BoolValue *>> Condition::StrongestInferences(Function *f) {
@@ -147,6 +148,7 @@ std::set<BoolValue> LogicalOp::BoolValues() const {
 
 bool BoolValue::Eval() const {
   assert(false && "Can't evaluate a branch - expression not constant!");
+  __builtin_unreachable();
 }
 
 bool And::Eval() const {

--- a/tesla/static/AcquireReleaseCheck.cpp
+++ b/tesla/static/AcquireReleaseCheck.cpp
@@ -16,7 +16,6 @@ AcquireReleaseCheck::AcquireReleaseCheck(const tesla::Automaton &A,
   ModulePass(ID), 
   correctUsage(true),
   boundName(A.Use()->beginning().function().function().name()),
-  automaton(A),
   args(args_)
 {
 }

--- a/tesla/static/AcquireReleaseCheck.h
+++ b/tesla/static/AcquireReleaseCheck.h
@@ -29,7 +29,6 @@ struct AcquireReleaseCheck : public ModulePass {
 private:
   bool correctUsage;
   const string boundName;
-  const tesla::Automaton &automaton;
   std::vector<tesla::Argument> args;
 };
 

--- a/tesla/static/CallSequencePass.cpp
+++ b/tesla/static/CallSequencePass.cpp
@@ -8,10 +8,7 @@ namespace tesla {
 unique_ptr<Manifest> CallSequencePass::run(Manifest &Man, llvm::Module &Mo) {
   auto File = new ManifestFile();
 
-  auto main = Mo.getFunction("main");
   auto f = Mo.getFunction("f");
-  auto g = Mo.getFunction("g");
-  auto h = Mo.getFunction("h");
   if(f) {
     auto tcs = TransitiveCallsOnce(Mo, f);
     for(auto fn : tcs) {


### PR DESCRIPTION
There were a few places where assert(false) lead to the compiler marking
a function as not returning - these have been annotated with
__builtin_unreachable() to stop this from happening.