### PR TITLE
Fixes a bug with calls across translation units

### DIFF
--- a/tesla/common/Arguments.cpp
+++ b/tesla/common/Arguments.cpp
@@ -183,3 +183,16 @@ void tesla::ParseAssertionLocation(
 
   Loc->set_counter(Count->getLimitedValue(INT_MAX));
 }
+
+llvm::Function* calledOrCastFunction(llvm::CallInst *ci)
+{
+  if(auto cst = llvm::dyn_cast<llvm::ConstantExpr>(ci->getOperand(0))) {
+    if(cst->isCast()) {
+      if(auto fn = llvm::dyn_cast<llvm::Function>(cst->getOperand(0))) {
+        return fn;
+      }
+    }
+  }
+
+  return ci->getCalledFunction();
+}

--- a/tesla/common/Arguments.h
+++ b/tesla/common/Arguments.h
@@ -41,6 +41,9 @@ llvm::Value* GetArgumentValue(llvm::Value* Param, const Argument& ArgDescrip,
  * pseudo-call.
  */
 void ParseAssertionLocation(Location *Loc, llvm::CallInst*);
+
 }
+
+llvm::Function* calledOrCastFunction(llvm::CallInst *ci);
 
 #endif

--- a/tesla/model/include/EventGraph.h
+++ b/tesla/model/include/EventGraph.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <vector>
 
+#include "Arguments.h"
 #include "Inference.h"
 #include "Names.h"
 #include "tesla.pb.h"
@@ -201,8 +202,8 @@ struct EntryEvent : public Event {
 
   EntryEvent(EventGraph *g, CallInst *ci)
     : Event(EV_Enter, g),
-      Description(ci->getCalledFunction()->getName().str()), 
-      Func(ci->getCalledFunction()), 
+      Description(calledOrCastFunction(ci)->getName().str()), 
+      Func(calledOrCastFunction(ci)), 
       Call(ci) {}
 
   EntryEvent(string n)
@@ -230,8 +231,8 @@ struct ExitEvent : public Event {
 
   ExitEvent(EventGraph *g, CallInst *ci)
     : Event(EV_Exit, g), 
-      Description(ci->getCalledFunction()->getName().str()), 
-      Func(ci->getCalledFunction()), 
+      Description(calledOrCastFunction(ci)->getName().str()), 
+      Func(calledOrCastFunction(ci)), 
       Call(ci) {}
 
   ExitEvent(string n)

--- a/tesla/model/lib/GraphTransforms.cpp
+++ b/tesla/model/lib/GraphTransforms.cpp
@@ -27,8 +27,14 @@ Event *GraphTransforms::CallsOnly(Event *e) {
       if(called && !called->isDeclaration()) {
         return new CallEvent(ci);
       }
+
+      if(auto cst = dyn_cast<ConstantExpr>(ci->getOperand(0))) {
+        if(cst->isCast()) {
+          return new CallEvent(ci);
+        }
+      }
     }
-    
+
     return new EmptyEvent;
   }
 


### PR DESCRIPTION
If a call is made to a function in another translation unit (even after
linking into a single LLVM module), the CallInst hides the called
function behind a bitcast. This PR fixes the issue by adding a uniform
accessor to called functions, even with this interposition