### PR TITLE
Improve boolean inference performance

### DIFF
--- a/tesla/model/include/ImplicationCheck.h
+++ b/tesla/model/include/ImplicationCheck.h
@@ -17,12 +17,12 @@ namespace Implication {
  *    and checking on all the possible valuations generated (i.e. set b to false
  *    and check that every valuation then evals to false as well).
  */
-bool Check(Condition *c, BoolValue b);
+bool Check(const Condition *c, BoolValue b);
 
 /**
  * Generate the set of all implied branches for a particular condition.
  */
-std::set<BoolValue> BoolValuesFrom(Condition *c);
+std::set<BoolValue> BoolValuesFrom(const Condition *c);
 
 }
 

--- a/tesla/model/lib/ImplicationCheck.cpp
+++ b/tesla/model/lib/ImplicationCheck.cpp
@@ -1,6 +1,6 @@
 #include "ImplicationCheck.h"
 
-bool Implication::Check(Condition *c, BoolValue b) {
+bool Implication::Check(const Condition *c, BoolValue b) {
   auto not_b = *b.Negated();
 
   auto allBoolValues = c->BoolValues();
@@ -12,10 +12,10 @@ bool Implication::Check(Condition *c, BoolValue b) {
     }
   }
 
-  std::vector<Condition *> workingSet{c};
+  std::vector<const Condition *> workingSet{c};
 
   for(auto branch : extras) {
-    std::vector<Condition *> updated;
+    std::vector<const Condition *> updated;
 
     for(auto cond : workingSet) {
       updated.push_back(cond->Restricted(branch, new ConstTrue, new ConstFalse));
@@ -26,14 +26,14 @@ bool Implication::Check(Condition *c, BoolValue b) {
   }
 
   return std::none_of(workingSet.begin(), workingSet.end(),
-    [=](Condition *w) {
+    [=](auto w) {
       auto val = w->Restricted(b, new ConstFalse, new ConstTrue);
       return val->Eval();
     }
   );
 }
 
-std::set<BoolValue> Implication::BoolValuesFrom(Condition *c) {
+std::set<BoolValue> Implication::BoolValuesFrom(const Condition *c) {
   std::set<BoolValue> ret;
 
   for(auto branch : c->BoolValues()) {


### PR DESCRIPTION
If we don't have an easy simplification available, the size of generated
inferences can start to grow enormously - this change stops this from
happening by backing off to always simplify to a single-depth AND built
from the inferences we have available from the zero-removed condition.