### PR TITLE
Fix operand index for complex casts

### DIFF
--- a/tesla/common/Arguments.cpp
+++ b/tesla/common/Arguments.cpp
@@ -186,7 +186,8 @@ void tesla::ParseAssertionLocation(
 
 llvm::Function* calledOrCastFunction(llvm::CallInst *ci)
 {
-  if(auto cst = llvm::dyn_cast<llvm::ConstantExpr>(ci->getOperand(0))) {
+  auto num = ci->getNumOperands() - 1;
+  if(auto cst = llvm::dyn_cast<llvm::ConstantExpr>(ci->getOperand(num))) {
     if(cst->isCast()) {
       if(auto fn = llvm::dyn_cast<llvm::Function>(cst->getOperand(0))) {
         return fn;

--- a/tesla/model/lib/GraphTransforms.cpp
+++ b/tesla/model/lib/GraphTransforms.cpp
@@ -28,7 +28,8 @@ Event *GraphTransforms::CallsOnly(Event *e) {
         return new CallEvent(ci);
       }
 
-      if(auto cst = dyn_cast<ConstantExpr>(ci->getOperand(0))) {
+      auto num = ci->getNumOperands() - 1;
+      if(auto cst = dyn_cast<ConstantExpr>(ci->getOperand(num))) {
         if(cst->isCast()) {
           return new CallEvent(ci);
         }


### PR DESCRIPTION
Sometimes, the function being cast isn't at index 0 - I think the
generalisation is that it's always at the last index, but that could be
wrong. Seems to work for now.