### PR TITLE
Configurable options for the model checker

### DIFF
--- a/tesla/model/include/ModelChecker.h
+++ b/tesla/model/include/ModelChecker.h
@@ -66,6 +66,10 @@ private:
   tesla::Manifest *Manifest;
   Function *Bound;
   int Depth;
+  
+  // internal options configuring the search for counterexamples
+  bool PreferTerminating = true;
+  bool Sequential = false;
 };
 
 #endif


### PR DESCRIPTION
This allows users of the model checker to prefer terminating counterexamples, and to run only a single thread to guarantee sequential behaviour.