### PR TITLE
Add complete instrumentation removal

### DIFF
--- a/tesla/common/Manifest.cpp
+++ b/tesla/common/Manifest.cpp
@@ -69,6 +69,15 @@ Manifest::~Manifest() {
     delete i.second;
 }
 
+bool Manifest::HasInstrumentation() const {
+  auto&& usages = RootAutomata();
+  return std::any_of(std::begin(usages), std::end(usages),
+    [](auto use) {
+      return !use->deleted();
+    }
+  );
+}
+
 const Automaton* Manifest::FindAutomaton(const Identifier& ID) const {
   auto i = Automata.find(ID);
   if (i == Automata.end())

--- a/tesla/common/Manifest.h
+++ b/tesla/common/Manifest.h
@@ -63,6 +63,9 @@ public:
   //! Top-level automata (named explicitly in code).
   llvm::ArrayRef<const Usage*> RootAutomata() const { return Roots; }
 
+  //! Have all the usages in this manifest been deleted by static analysis? 
+  bool HasInstrumentation() const;
+
   //! All automata in the manifest file.
   const AutomataMap& AllAutomata() const { return Descriptions; }
 

--- a/tesla/common/Names.cpp
+++ b/tesla/common/Names.cpp
@@ -34,6 +34,7 @@
 
 #include <llvm/ADT/Twine.h>
 
+#include <algorithm>
 #include <string>
 #include <sstream>
 

--- a/tesla/common/Names.h
+++ b/tesla/common/Names.h
@@ -109,4 +109,10 @@ std::string InstanceName(const ReferenceVector&,
 
 } /* namespace tesla */
 
+template<class Input>
+bool has_prefix(Input haystack, Input needle) {
+  return haystack.size() >= needle.size() &&
+    std::equal(std::begin(needle), std::end(needle), std::begin(haystack));
+}
+
 #endif

--- a/tesla/common/tesla.proto
+++ b/tesla/common/tesla.proto
@@ -60,7 +60,7 @@ message Usage {
   optional Expression end = 3;
 
   /** Should this usage be instrumented or ignored (based on static analysis)? **/
-  optional bool deleted = 4;
+  optional bool deleted = 4 [ default = false ];
 }
 
 

--- a/tesla/instrumenter/CMakeLists.txt
+++ b/tesla/instrumenter/CMakeLists.txt
@@ -13,11 +13,12 @@ add_llvm_executable(tesla-instrument
 	Assertion.cpp
 	Callee.cpp
 	Caller.cpp
-  EventTranslator.cpp
+        EventTranslator.cpp
 	FieldReference.cpp
-  InstrContext.cpp
+        InstrContext.cpp
 	Instrumentation.cpp
-  TranslationFn.cpp
+        Remove.cpp
+        TranslationFn.cpp
 )
 
 target_link_libraries(tesla-instrument

--- a/tesla/instrumenter/Remove.cpp
+++ b/tesla/instrumenter/Remove.cpp
@@ -1,0 +1,51 @@
+#include "Names.h"
+#include "Remove.h"
+
+#include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
+
+using namespace llvm;
+
+namespace tesla {
+
+char RemoveInstrumenter::ID = 0;
+
+RemoveInstrumenter::~RemoveInstrumenter() {
+  ::google::protobuf::ShutdownProtobufLibrary();
+}
+
+bool RemoveInstrumenter::runOnModule(Module &M) {
+  auto to_delete = std::set<Instruction *>{};
+
+  for(auto& F : M) {
+    for(auto& BB : F) {
+      for(auto& I : BB) {
+        if(ShouldDelete(I)) {
+          to_delete.insert(&I);
+        }
+      }
+    }
+  }
+
+  for(auto I : to_delete) {
+    I->eraseFromParent();
+  }
+
+  return true;
+}
+
+bool RemoveInstrumenter::ShouldDelete(llvm::Instruction &I) {
+  if(auto ci = dyn_cast<CallInst>(&I)) {
+    auto cf = ci->getCalledFunction();
+    if(!cf) { return false; }
+
+    auto name = cf->getName().str();
+    if(has_prefix(name, TESLA_BASE)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+}

--- a/tesla/instrumenter/Remove.h
+++ b/tesla/instrumenter/Remove.h
@@ -1,0 +1,32 @@
+#ifndef INSTRUMENTER_REMOVE_H
+#define INSTRUMENTER_REMOVE_H
+
+#include "Instrumenter.h"
+#include "Transition.h"
+
+#include <llvm/IR/Instruction.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Pass.h>
+
+namespace tesla {
+
+class RemoveInstrumenter : public Instrumenter, public llvm::ModulePass {
+public:
+  static char ID;
+  RemoveInstrumenter(const Manifest& M, bool SuppressDI)
+    : Instrumenter(M, SuppressDI), ModulePass(ID) {}
+  virtual ~RemoveInstrumenter();
+
+  const char* getPassName() const {
+    return "TESLA assertion site instrumenter";
+  }
+
+  virtual bool runOnModule(llvm::Module &M);
+
+private:
+  bool ShouldDelete(llvm::Instruction &I);
+};
+
+}
+
+#endif

--- a/tesla/instrumenter/instrument.cpp
+++ b/tesla/instrumenter/instrument.cpp
@@ -19,6 +19,7 @@
 #include "Debug.h"
 #include "FieldReference.h"
 #include "Manifest.h"
+#include "Remove.h"
 
 #include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/Verifier.h>
@@ -146,10 +147,14 @@ int main(int argc, char **argv) {
     Passes.add(TD);
 
   // Just add TESLA instrumentation passes.
-  addPass(Passes, new tesla::AssertionSiteInstrumenter(*Manifest, SuppressDI));
-  addPass(Passes, new tesla::FnCalleeInstrumenter(*Manifest, SuppressDI));
-  addPass(Passes, new tesla::FnCallerInstrumenter(*Manifest, SuppressDI));
-  addPass(Passes, new tesla::FieldReferenceInstrumenter(*Manifest, SuppressDI));
+  if(Manifest->HasInstrumentation()) {
+    addPass(Passes, new tesla::AssertionSiteInstrumenter(*Manifest, SuppressDI));
+    addPass(Passes, new tesla::FnCalleeInstrumenter(*Manifest, SuppressDI));
+    addPass(Passes, new tesla::FnCallerInstrumenter(*Manifest, SuppressDI));
+    addPass(Passes, new tesla::FieldReferenceInstrumenter(*Manifest, SuppressDI));
+  } else {
+    addPass(Passes, new tesla::RemoveInstrumenter(*Manifest, SuppressDI));
+  }
 
   // Write bitcode or assembly to the output as the last step...
   if (!NoOutput) {


### PR DESCRIPTION
If all the usages in a manifest are deleted, then we should perform no
instrumentation at all (previously, lots of setup code was left in the
executables). This PR adds a new pass that just removes TESLA magic
function calls if safe to do so. Otherwise, the previous instrumentation
code will run unmodified.