### PR TITLE
Z3

### DIFF
--- a/tesla/trace/CMakeLists.txt
+++ b/tesla/trace/CMakeLists.txt
@@ -6,7 +6,8 @@ add_llvm_executable(tesla-trace
   smt_text_gen.cpp
   stub_functions_pass.cpp
   inline_all_pass.cpp
+  z3_solve.cpp
 )
-target_link_libraries(tesla-trace ${LLVM_LIBS})
+target_link_libraries(tesla-trace z3 ${LLVM_LIBS})
 
 install(TARGETS tesla-trace DESTINATION bin)

--- a/tesla/trace/CMakeLists.txt
+++ b/tesla/trace/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD})
 add_llvm_executable(tesla-trace 
   trace.cpp
   trace_finder.cpp
-  smt_gen.cpp
+  smt_text_gen.cpp
   stub_functions_pass.cpp
   inline_all_pass.cpp
 )

--- a/tesla/trace/smt_text_gen.cpp
+++ b/tesla/trace/smt_text_gen.cpp
@@ -3,9 +3,9 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/Support/raw_ostream.h>
 
-#include "smt_gen.h"
+#include "smt_text_gen.h"
 
-SMTVisitor::SMTVisitor(Function& f, ValueMap<Value *, std::string>& ns) :
+SMTTextVisitor::SMTTextVisitor(Function& f, ValueMap<Value *, std::string>& ns) :
   function_(f), names_(ns)
 {
   for(const auto& pair : names_) {
@@ -18,7 +18,7 @@ SMTVisitor::SMTVisitor(Function& f, ValueMap<Value *, std::string>& ns) :
   ss << "(set-logic QF_UFLIA)\n";
 }
 
-void SMTVisitor::run()
+void SMTTextVisitor::run()
 {
   visit(function_);
   auto& sink = *std::find_if(std::begin(function_), std::end(function_),
@@ -42,13 +42,13 @@ void SMTVisitor::run()
   }
 }
 
-void SMTVisitor::check()
+void SMTTextVisitor::check()
 {
   ss << "(check-sat)\n";
   ss << "(get-model)\n";
 }
 
-void SMTVisitor::visitBinaryOperator(BinaryOperator &BO)
+void SMTTextVisitor::visitBinaryOperator(BinaryOperator &BO)
 {
   auto define = [&](std::string op) {
     ss << "(define-fun |" << names_[&BO] << "| () ";
@@ -95,7 +95,7 @@ void SMTVisitor::visitBinaryOperator(BinaryOperator &BO)
   }
 }
 
-void SMTVisitor::visitCallInst(CallInst &CI)
+void SMTTextVisitor::visitCallInst(CallInst &CI)
 {
   ss << "(declare-fun |" << names_[&CI] << "| () ";
   if(called_returns_bool(CI)) {
@@ -106,7 +106,7 @@ void SMTVisitor::visitCallInst(CallInst &CI)
   ss << ")\n";
 }
 
-void SMTVisitor::visitLoadInst(LoadInst &LI)
+void SMTTextVisitor::visitLoadInst(LoadInst &LI)
 {
   if(auto int_ty = dyn_cast<IntegerType>(LI.getType())) {
     auto width = int_ty->getBitWidth();
@@ -121,7 +121,7 @@ void SMTVisitor::visitLoadInst(LoadInst &LI)
   }
 }
 
-void SMTVisitor::visitCmpInst(CmpInst &CI)
+void SMTTextVisitor::visitCmpInst(CmpInst &CI)
 {
   if(!CI.isIntPredicate()) {
     return;
@@ -167,7 +167,7 @@ void SMTVisitor::visitCmpInst(CmpInst &CI)
   }
 }
 
-std::string SMTVisitor::operand_str(Value *V) const
+std::string SMTTextVisitor::operand_str(Value *V) const
 {
   auto found = names_.find(V);
   if(found != names_.end()) {
@@ -190,7 +190,7 @@ std::string SMTVisitor::operand_str(Value *V) const
   return "__bad_operand__";
 }
 
-bool SMTVisitor::called_returns_bool(CallInst &CI) const
+bool SMTTextVisitor::called_returns_bool(CallInst &CI) const
 {
   auto fn = CI.getCalledFunction();
   if(!fn) { return false; }

--- a/tesla/trace/smt_text_gen.cpp
+++ b/tesla/trace/smt_text_gen.cpp
@@ -40,10 +40,7 @@ void SMTTextVisitor::run()
       }
     }
   }
-}
 
-void SMTTextVisitor::check()
-{
   ss << "(check-sat)\n";
   ss << "(get-model)\n";
 }

--- a/tesla/trace/smt_text_gen.h
+++ b/tesla/trace/smt_text_gen.h
@@ -12,9 +12,9 @@
 
 using namespace llvm;
 
-class SMTVisitor : public InstVisitor<SMTVisitor> {
+class SMTTextVisitor : public InstVisitor<SMTTextVisitor> {
 public:
-  SMTVisitor(Function &f, ValueMap<Value *, std::string>& ns);
+  SMTTextVisitor(Function &f, ValueMap<Value *, std::string>& ns);
 
   void run();
 

--- a/tesla/trace/trace.cpp
+++ b/tesla/trace/trace.cpp
@@ -13,6 +13,7 @@
 #include "smt_text_gen.h"
 #include "stub_functions_pass.h"
 #include "trace_finder.h"
+#include "z3_solve.h"
 
 using namespace llvm;
 
@@ -63,10 +64,10 @@ int main(int argc, char **argv)
       if(SMT2TextOutput) {
         auto gen = SMTTextVisitor(*tr_fn, names); 
         gen.run();
-        gen.check();
         outs() << gen.str() << '\n';
       } else {
-        outs() << "Z3 Internal Mode!\n";
+        auto&& z3 = Z3Visitor(*tr_fn, names);
+        z3.run();
       }
     }
   }

--- a/tesla/trace/trace.cpp
+++ b/tesla/trace/trace.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
   inliner.runOnFunction(*function);
 
   auto finder = TraceFinder(*function);
-  auto trs = finder.of_length_up_to(10);
+  auto trs = finder.of_length_up_to(25);
   for(const auto& trace : trs) {
     auto&& names = ValueMap<Value *, std::string>{};
     if(auto tr_fn = finder.from_trace(trace, names)) {

--- a/tesla/trace/trace.cpp
+++ b/tesla/trace/trace.cpp
@@ -10,7 +10,7 @@
 #include <llvm/PassManager.h>
 
 #include "inline_all_pass.h"
-#include "smt_gen.h"
+#include "smt_text_gen.h"
 #include "stub_functions_pass.h"
 #include "trace_finder.h"
 
@@ -21,6 +21,9 @@ BitcodeFilename(cl::Positional, cl::desc("bitcode"), cl::Required);
 
 static cl::opt<std::string>
 FunctionName("f", cl::desc("function"), cl::init("main"));
+
+static cl::opt<bool>
+SMT2TextOutput("smt2", cl::desc("output SMT2 textual form"), cl::init(false));
 
 int main(int argc, char **argv)
 {
@@ -55,12 +58,16 @@ int main(int argc, char **argv)
   for(const auto& trace : trs) {
     auto&& names = ValueMap<Value *, std::string>{};
     if(auto tr_fn = finder.from_trace(trace, names)) {
-      tr_fn->dump();
+      //tr_fn->dump();
 
-      auto gen = SMTVisitor(*tr_fn, names); 
-      gen.run();
-      gen.check();
-      outs() << gen.str() << '\n';
+      if(SMT2TextOutput) {
+        auto gen = SMTTextVisitor(*tr_fn, names); 
+        gen.run();
+        gen.check();
+        outs() << gen.str() << '\n';
+      } else {
+        outs() << "Z3 Internal Mode!\n";
+      }
     }
   }
   return 0;

--- a/tesla/trace/z3_solve.cpp
+++ b/tesla/trace/z3_solve.cpp
@@ -1,0 +1,114 @@
+#include <llvm/Support/raw_ostream.h>
+#include <iostream>
+
+#include "z3_solve.h"
+
+void Z3Visitor::run()
+{
+  visit(function_);
+  errs() << str() << '\n';
+}
+
+void Z3Visitor::visitBinaryOperator(BinaryOperator &BO)
+{
+  auto result = value_expr(&BO);
+  auto lhs = value_expr(BO.getOperand(0));
+  auto rhs = value_expr(BO.getOperand(1));
+
+  auto body = [&] {
+    switch(BO.getOpcode()) {
+    case Instruction::Add: return lhs + rhs;
+    case Instruction::Sub: return lhs - rhs;
+    case Instruction::Mul: return lhs * rhs;
+    case Instruction::Xor: return lhs != rhs;
+    case Instruction::Or: return lhs || rhs;
+    case Instruction::And: return lhs && rhs;
+    default:
+      BO.dump();
+      assert(false && "Unhandled operation");
+    }
+  }();
+
+  solver_.add(result == body);
+}
+
+void Z3Visitor::visitCallInst(CallInst &CI)
+{
+  /*auto fn = cast<Function>(CI.getCalledValue()->stripPointerCasts());
+  auto result_ty = fn->getFunctionType()->getReturnType();
+  if(isa<IntegerType>(result_ty)) {
+    solver_.add(value_expr(&CI));
+  }*/
+}
+
+void Z3Visitor::visitLoadInst(LoadInst &LI)
+{
+}
+
+void Z3Visitor::visitCmpInst(CmpInst &CI)
+{
+  if(!CI.isIntPredicate()) {
+    return;
+  }
+
+  auto result = value_expr(&CI);
+  auto lhs = value_expr(CI.getOperand(0));
+  auto rhs = value_expr(CI.getOperand(1));
+
+  auto body = [&] {
+    switch(CI.getPredicate()) {
+    case CmpInst::ICMP_EQ: return lhs == rhs;
+    case CmpInst::ICMP_NE: return lhs != rhs;
+    case CmpInst::ICMP_UGT:
+    case CmpInst::ICMP_SGT: return lhs > rhs;
+    case CmpInst::ICMP_UGE:
+    case CmpInst::ICMP_SGE: return lhs >= rhs;
+    case CmpInst::ICMP_ULT:
+    case CmpInst::ICMP_SLT: return lhs < rhs;
+    case CmpInst::ICMP_ULE:
+    case CmpInst::ICMP_SLE: return lhs <= rhs; 
+    default:
+      CI.dump();
+      assert(false && "Unhandled comparison op!");
+    }
+  }();
+
+  solver_.add(result == body);
+}
+
+std::string Z3Visitor::str() const
+{
+  std::stringstream ss;
+  ss << solver_;
+  return ss.str();
+}
+
+z3::sort Z3Visitor::value_sort(Value *v)
+{
+  auto width = cast<IntegerType>(v->getType())->getBitWidth();
+  if(width == 1) {
+    return context_.bool_sort();
+  } else {
+    return context_.int_sort();
+  }
+}
+
+z3::expr Z3Visitor::value_expr(Value *v)
+{
+  auto name = names_.find(v);
+  if(name != names_.end()) {
+    auto sort = value_sort(v);
+    return context_.constant(name->second.c_str(), sort);
+  }
+
+  if(auto cst = dyn_cast<ConstantInt>(v)) {
+    if(cst->getBitWidth() == 1) {
+      return context_.bool_val(cst->isOne());
+    } else {
+      return context_.int_val((__int64)cst->getSExtValue());
+    }
+  }
+
+  v->dump();
+  assert(false && "Unhandled value - can't get Z3 expr!");
+}

--- a/tesla/trace/z3_solve.h
+++ b/tesla/trace/z3_solve.h
@@ -17,11 +17,11 @@ public:
   Z3Visitor(Function &f, ValueMap<Value *, std::string>& ns) :
     function_(f), names_(ns), solver_(context_) {}
 
+  const std::map<CallInst *, long long> get_constraints() const { return constraints_; }
+
   void run();
 
   void visitBinaryOperator(BinaryOperator &BO);
-  void visitCallInst(CallInst &CI);
-  void visitLoadInst(LoadInst &LI);
   void visitCmpInst(CmpInst &CI);
 
   std::string str() const;
@@ -33,6 +33,10 @@ private:
 
   z3::sort value_sort(Value *);
   z3::expr value_expr(Value *v);
+
+  Value *reverse_name_lookup(std::string name) const;
+
+  std::map<CallInst *, long long> constraints_;
 };
 
 #endif

--- a/tesla/trace/z3_solve.h
+++ b/tesla/trace/z3_solve.h
@@ -1,20 +1,21 @@
-#ifndef SMT_GEN_H
-#define SMT_GEN_H
+#ifndef Z3_SOLVE_H
+#define Z3_SOLVE_H
 
-#include <map>
 #include <sstream>
-#include <string>
 
 #include <llvm/InstVisitor.h>
 #include <llvm/ADT/ValueMap.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 
+#include <z3++.h>
+
 using namespace llvm;
 
-class SMTTextVisitor : public InstVisitor<SMTTextVisitor> {
+class Z3Visitor : public InstVisitor<Z3Visitor> {
 public:
-  SMTTextVisitor(Function &f, ValueMap<Value *, std::string>& ns);
+  Z3Visitor(Function &f, ValueMap<Value *, std::string>& ns) :
+    function_(f), names_(ns), solver_(context_) {}
 
   void run();
 
@@ -23,14 +24,15 @@ public:
   void visitLoadInst(LoadInst &LI);
   void visitCmpInst(CmpInst &CI);
 
-  std::string str() const { return ss.str(); }
+  std::string str() const;
 private:
-  std::string operand_str(Value *V) const;
-  bool called_returns_bool(CallInst &ci) const;
-  
-  Function& function_;
+  Function &function_;
   ValueMap<Value *, std::string>& names_;
-  std::stringstream ss;
+  z3::context context_;
+  z3::solver solver_;
+
+  z3::sort value_sort(Value *);
+  z3::expr value_expr(Value *v);
 };
 
 #endif


### PR DESCRIPTION
This PR integrates the Z3 theorem prover into the new version of the model checker. Z3 is used in its library form to compute constraints on the return values of particular call instances in a function trace. 

To do this, I have added a partial translation of LLVM values into a collection of boolean / integer constants that can be solved in an appropriate SMT logic.