### PR TITLE
Add CFG simplification

### DIFF
--- a/tesla/static/Z3Pass.cpp
+++ b/tesla/static/Z3Pass.cpp
@@ -46,10 +46,14 @@ bool Z3Pass::CheckUsage(Manifest &man, Module &mod, const Usage *use)
   }
 
   if(inlined_functions_.find(bound) == inlined_functions_.end()) {
-    auto&& inliner = InlineAllPass(inline_depth_);
-    inliner.runOnFunction(*bound);
+    FunctionPassManager Passes(&mod);
+    Passes.add(new InlineAllPass(inline_depth_));
+    Passes.add(createCFGSimplificationPass());
+    Passes.run(*bound);
+
     inlined_functions_.insert(bound);
   }
+  bound->dump();
 
   auto automaton = man.FindAutomaton(use->identifier());
   auto expr = automaton->getAssertion().expression();

--- a/tesla/trace/lib/z3_checker.cpp
+++ b/tesla/trace/lib/z3_checker.cpp
@@ -218,7 +218,7 @@ bool Z3TraceChecker::is_safe() const
 {
   auto no_asserts_checked = std::none_of(trace_.begin(), trace_.end(),
     [](auto bb) {
-      return std::none_of(bb->begin(), bb->end(),
+      return std::any_of(bb->begin(), bb->end(),
         [](auto& I) {
           if(auto ci = dyn_cast<CallInst>(&I)) {
             return calledOrCastFunction(ci)->getName().str() == tesla::INLINE_ASSERTION;


### PR DESCRIPTION
This makes the exponential behaviour of the new model checker far less
catastrophic. Additionally, fixes a bug in the no-assertions check.