### PR TITLE
Counterexamples

### DIFF
--- a/cmake/Tesla.cmake
+++ b/cmake/Tesla.cmake
@@ -75,7 +75,7 @@ function(add_tesla_executable C_SOURCES EXE_NAME STATIC)
   if(STATIC AND CMAKE_USE_STATIC)
     add_custom_command(
       OUTPUT ${EXE_NAME}.static.manifest
-      COMMAND tesla static ${EXE_NAME}.manifest ${EXE_NAME}.bc -modelcheck -bound=1000 -o ${EXE_NAME}.static.manifest
+      COMMAND tesla static ${EXE_NAME}.manifest ${EXE_NAME}.bc -z3 -bound=50 -o ${EXE_NAME}.static.manifest
       DEPENDS ${EXE_NAME}.manifest ${EXE_NAME}.bc
     )
     add_custom_target(${EXE_NAME}-static-manifest

--- a/tesla/static/Z3Pass.cpp
+++ b/tesla/static/Z3Pass.cpp
@@ -62,8 +62,9 @@ bool Z3Pass::CheckUsage(Manifest &man, Module &mod, const Usage *use)
   auto automaton = man.FindAutomaton(use->identifier());
   auto expr = automaton->getAssertion().expression();
 
-  auto safe = Z3Checker{*bound, man, expr, bmc_bound_}.is_safe();
+  auto&& safe = Z3Checker{*bound, man, expr, bmc_bound_}.is_safe();
   if(!safe && PrintCounterexamples) {
+    safe.dump();
   }
   return safe;
 }

--- a/tesla/static/Z3Pass.cpp
+++ b/tesla/static/Z3Pass.cpp
@@ -1,4 +1,5 @@
 #include <llvm/PassManager.h>
+#include <llvm/Support/CommandLine.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Scalar.h>
 
@@ -6,6 +7,10 @@
 #include "stub_functions_pass.h"
 #include "z3_checker.h"
 #include "Z3Pass.h"
+
+static cl::opt<bool>
+PrintCounterexamples("print-counter", cl::desc("Print counterexample info to stderr"),
+                     cl::init(false));                     
 
 namespace tesla {
 
@@ -57,7 +62,10 @@ bool Z3Pass::CheckUsage(Manifest &man, Module &mod, const Usage *use)
   auto automaton = man.FindAutomaton(use->identifier());
   auto expr = automaton->getAssertion().expression();
 
-  return Z3Checker{*bound, man, expr, bmc_bound_}.is_safe();
+  auto safe = Z3Checker{*bound, man, expr, bmc_bound_}.is_safe();
+  if(!safe && PrintCounterexamples) {
+  }
+  return safe;
 }
 
 bool Z3Pass::has_checkable_bounds(const tesla::Usage *use) const

--- a/tesla/trace/include/z3_checker.h
+++ b/tesla/trace/include/z3_checker.h
@@ -36,6 +36,9 @@ private:
   static std::vector<std::string> call_stack_from_trace(
       std::vector<const BasicBlock *> trace, const CallInst *fail);
 
+  void dump_unexpected() const;
+  void dump_incomplete() const;
+
   std::vector<std::string> call_stack_;
   const CallInst* event_;
   std::shared_ptr<::State> state_;
@@ -47,7 +50,7 @@ public:
   Z3Checker(Function& bound, tesla::Manifest& man, 
             tesla::Expression& expr, size_t depth);
 
-  bool is_safe() const;
+  CheckResult is_safe() const;
 
 private:
   Function& bound_;
@@ -62,6 +65,8 @@ public:
                  const FiniteStateMachine<tesla::Expression *>& fsm);
 
   CheckResult is_safe() const;
+
+  static std::string remove_stub(const std::string name);
 private: 
   bool check_event(const CallInst& CI, const tesla::Expression& expr) const;
   bool check_function(const CallInst& CI, const tesla::FunctionEvent& expr) const;
@@ -70,7 +75,6 @@ private:
   std::pair<std::shared_ptr<::State>, CheckResult> 
     next_state(const CallInst& CI, std::shared_ptr<::State> state) const;
 
-  std::string remove_stub(const std::string name) const;
   bool possibly_checked(const CallInst& CI) const;
 
   Function &bound_;

--- a/tesla/trace/include/z3_checker.h
+++ b/tesla/trace/include/z3_checker.h
@@ -52,4 +52,31 @@ private:
   const FiniteStateMachine<tesla::Expression *>& fsm_;
 };
 
+class CheckResult {
+public:
+  enum FailureReason {
+    Constraint, Incomplete, Unexpected, None
+  };
+
+  CheckResult() :
+    reason_(None) {}
+
+  CheckResult(FailureReason fail, std::vector<const BasicBlock *> trace,
+              CallInst* event, tesla::Expression* expr) :
+    call_stack_(call_stack_from_trace(trace, event)),
+    event_(event), expr_(expr), reason_(fail) {}
+
+  void dump() const;
+
+  operator bool() const { return reason_ == None; }
+private:
+  static std::vector<std::string> call_stack_from_trace(
+      std::vector<const BasicBlock *> trace, CallInst *fail);
+
+  std::vector<std::string> call_stack_;
+  CallInst* event_;
+  tesla::Expression* expr_;
+  FailureReason reason_;
+};
+
 #endif

--- a/tesla/trace/lib/trace_finder.cpp
+++ b/tesla/trace/lib/trace_finder.cpp
@@ -1,4 +1,6 @@
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
@@ -86,12 +88,6 @@ std::shared_ptr<Function> TraceFinder::from_trace(trace_type tr, ValueMap<Value 
 
   auto trace_fn = Function::Create(fn_type, GlobalValue::ExternalLinkage, 
                                    "trace_" + function_.getName() + "_" + std::to_string(tr.size()));
-  /*auto to_it = trace_fn->arg_begin();
-  for(auto from_it = function_.arg_begin();
-      to_it != trace_fn->arg_end() && from_it != function_.arg_end();
-      to_it++, from_it++) {
-    arg_map[from_it] = to_it;
-  }*/
 
   auto sink = BasicBlock::Create(function_.getContext(), "__tesla_sink", trace_fn);
   new UnreachableInst(function_.getContext(), sink);

--- a/tesla/trace/lib/z3_checker.cpp
+++ b/tesla/trace/lib/z3_checker.cpp
@@ -177,9 +177,13 @@ bool Z3TraceChecker::check_function(const CallInst& CI, const tesla::FunctionEve
 
 bool Z3TraceChecker::check_assert(const CallInst& CI, const tesla::AssertionSite& expr) const
 {
-  auto loc = tesla::Location{};
-  tesla::ParseAssertionLocation(&loc, &CI);
-  return expr.location() == loc;
+  if(calledOrCastFunction(&CI)->getName().str() == tesla::INLINE_ASSERTION) {
+    auto loc = tesla::Location{};
+    tesla::ParseAssertionLocation(&loc, &CI);
+    return expr.location() == loc;
+  }
+
+  return false;
 }
 
 std::pair<std::shared_ptr<::State>, bool> 

--- a/tesla/trace/lib/z3_checker.cpp
+++ b/tesla/trace/lib/z3_checker.cpp
@@ -251,3 +251,14 @@ bool Z3TraceChecker::is_safe() const
   
   return state->accepting;
 }
+
+std::vector<std::string> 
+CheckResult::call_stack_from_trace(std::vector<const BasicBlock *> trace, 
+                                   CallInst *fail)
+{
+  return {};
+}
+
+void CheckResult::dump() const
+{
+}

--- a/tesla/trace/lib/z3_checker.cpp
+++ b/tesla/trace/lib/z3_checker.cpp
@@ -4,6 +4,7 @@
 #include <llvm/PassManager.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Scalar.h>
+#include <llvm/Transforms/Utils/Cloning.h>
 
 #include "Arguments.h"
 #include "FSMBuilder.h"
@@ -41,11 +42,11 @@ Z3TraceChecker::Z3TraceChecker(Function& tf, Module& mod,
   }
 }
 
-bool Z3Checker::is_safe() const
+CheckResult Z3Checker::is_safe() const
 {
   auto finder = TraceFinder{bound_};
 
-  auto all_safe = true;
+  auto all_safe = CheckResult{};
   for(auto i = 0; i < depth_; i++) {
     auto traces = finder.of_length(i);
 
@@ -60,7 +61,7 @@ bool Z3Checker::is_safe() const
       }
 
       if(!all_safe) { 
-        return false;
+        return all_safe;
       }
     }
   }
@@ -196,10 +197,17 @@ Z3TraceChecker::next_state(const CallInst& CI, std::shared_ptr<::State> state) c
     }
   }
 
-  return std::make_pair(state, CheckResult{CheckResult::Unexpected, trace_, &CI, state});
+  ValueToValueMapTy VMap;
+  auto tc = CloneFunction(&bound_, VMap, false);
+  auto clone = cast<CallInst>(VMap[&CI]);
+
+  return std::make_pair(
+    state, 
+    CheckResult{CheckResult::Unexpected, TraceFinder::linear_trace(*tc), clone, state}
+  );
 }
 
-std::string Z3TraceChecker::remove_stub(const std::string name) const
+std::string Z3TraceChecker::remove_stub(const std::string name)
 {
   const auto prefixes = std::array<std::string, 2>{{"__entry_stub_", "__return_stub_"}};
   for(const auto& prefix : prefixes) {
@@ -260,9 +268,71 @@ std::vector<std::string>
 CheckResult::call_stack_from_trace(std::vector<const BasicBlock *> trace, 
                                    const CallInst *fail)
 {
-  return {};
+  using namespace std::string_literals;
+
+  std::vector<std::string> call_stack;
+
+  for(auto&& BB : trace) {
+    for(auto&& I : *BB) {
+      if(&I == fail) {
+        return call_stack;
+      }
+
+      if(auto ci = dyn_cast<CallInst>(&I)) {
+        auto name = calledOrCastFunction(ci)->getName().str();
+
+        if(has_prefix(name, "__entry_stub_"s)) {
+          call_stack.push_back(Z3TraceChecker::remove_stub(name));
+        }
+
+        if(has_prefix(name, "__return_stub_"s)) {
+          call_stack.pop_back();
+        }
+      }
+    }
+  }
+
+  assert(false && "Event not found on call stack!");
 }
 
 void CheckResult::dump() const
 {
+  assert(reason_ != None && "Shouldn't dump if safe");
+
+  errs() << "Counterexample found, ";
+  switch(reason_) {
+    case Incomplete: dump_incomplete(); break;
+    case Unexpected: dump_unexpected(); break;
+    default: errs() << "Unknown failure reason\n";
+  }
+  
+  errs() << "Call stack was:\n";
+  for(auto s : call_stack_) {
+    errs() << "  " << s << '\n';
+  }
+
+  errs() << '\n';
+}
+
+void CheckResult::dump_unexpected() const
+{
+  using namespace std::string_literals;
+
+  errs() << "unexpected event:\n";
+  auto name = calledOrCastFunction(event_)->getName().str();
+  auto called_name = Z3TraceChecker::remove_stub(name);
+
+  if(called_name == tesla::INLINE_ASSERTION) {
+    errs() << "  " << "Assertion site\n";
+  } else if(has_prefix(name, "__entry_stub"s)) {
+    errs() << "  " << "Call to " << called_name << '\n';
+  } else if(has_prefix(name, "__return_stub"s)) {
+    errs() << "  " << "Return from " << called_name << '\n';
+    errs() << "  " << "(return value may not be constrained)\n";
+  }
+}
+
+void CheckResult::dump_incomplete() const
+{
+  errs() << "incomplete event sequence:\n";
 }

--- a/tesla/trace/lib/z3_solve.cpp
+++ b/tesla/trace/lib/z3_solve.cpp
@@ -62,19 +62,20 @@ void Z3Visitor::visitBinaryOperator(BinaryOperator &BO)
 
   auto body = [&] {
     switch(BO.getOpcode()) {
-    case Instruction::Add: return lhs + rhs;
-    case Instruction::Sub: return lhs - rhs;
-    case Instruction::Mul: return lhs * rhs;
-    case Instruction::Xor: return lhs != rhs;
-    case Instruction::Or: return lhs || rhs;
-    case Instruction::And: return lhs && rhs;
+    case Instruction::Add: return std::make_pair(lhs + rhs, true);
+    case Instruction::Sub: return std::make_pair(lhs - rhs, true);
+    case Instruction::Mul: return std::make_pair(lhs * rhs, true);
+    case Instruction::Xor: return std::make_pair(lhs != rhs, true);
+    case Instruction::Or: return std::make_pair(lhs || rhs, true);
+    case Instruction::And: return std::make_pair(lhs && rhs, true);
     default:
-      BO.dump();
-      assert(false && "Unhandled operation");
+      return std::make_pair(z3::expr{context_}, false);
     }
   }();
 
-  solver_.add(result == body);
+  if(body.second) {
+    solver_.add(result == body.first);
+  }
 }
 
 void Z3Visitor::visitCmpInst(CmpInst &CI)


### PR DESCRIPTION
Generate slightly better counterexample messages that give a call stack and the reason for failure. There's still more room to improve here, but they work for now.