### PR TITLE
Check for unsatisfiable problems

### DIFF
--- a/tesla/static/model-checker/Z3Solver.cpp
+++ b/tesla/static/model-checker/Z3Solver.cpp
@@ -26,7 +26,12 @@ void Z3Visitor::run()
     }
   }
 
-  solver_.check();
+  auto result = solver_.check();
+  if(result != z3::sat) {
+    std::cerr << "Unsatisfiable return constraints - bad things happening\n";
+    return;
+  }
+
   auto m = solver_.get_model();
 
   for(auto i = 0; i < m.size(); i++) {


### PR DESCRIPTION
This prevents Z3 from throwing an exception when weird things happen on a trace and it's not satisfiable.