### PR TITLE
Fix warnings when building on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ link_directories(${LLVM_LIBDIR})
 
 # Always build with all warnings.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wstrict-prototypes")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fvisibility=hidden")
 
 # Disable RTTI usage in protocol buffers.
 #

--- a/tesla/common/tesla.proto
+++ b/tesla/common/tesla.proto
@@ -28,8 +28,9 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-package tesla;
+syntax = "proto2";
 
+package tesla;
 
 /**
  * A file that describes TESLA automata.


### PR DESCRIPTION
Minor issues - protoc wanted an explicit syntax marker, and compiling using Apple clang had some weird issues with symbol visibility.