### PR TITLE
Fixes to argument handling

### DIFF
--- a/tesla/static/model-checker/CheckResult.cpp
+++ b/tesla/static/model-checker/CheckResult.cpp
@@ -14,13 +14,21 @@ static bool is_assert(const CallInst* ci)
 static bool is_entry(const CallInst* ci)
 {
   using namespace std::string_literals;
-  return has_prefix(calledOrCastFunction(ci)->getName().str(), "__entry_stub_"s);
+  auto called_or_cast = calledOrCastFunction(ci);
+  if(!called_or_cast) {
+    return false;
+  }
+  return has_prefix(called_or_cast->getName().str(), "__entry_stub_"s);
 };
 
 static bool is_return(const CallInst* ci)
 {
   using namespace std::string_literals;
-  return has_prefix(calledOrCastFunction(ci)->getName().str(), "__return_stub_"s);
+  auto called_or_cast = calledOrCastFunction(ci);
+  if(!called_or_cast) {
+    return false;
+  }
+  return has_prefix(called_or_cast->getName().str(), "__return_stub_"s);
 };
 
 CheckResult::CheckResult(Status r, const Z3TraceChecker c, 
@@ -127,7 +135,8 @@ std::vector<std::string> CheckResult::call_stack() const
       }
 
       if(auto ci = dyn_cast<CallInst>(&I)) {
-        auto name = calledOrCastFunction(ci)->getName().str();
+        auto called_or_cast = calledOrCastFunction(ci);
+        auto name = called_or_cast ? called_or_cast->getName().str() : "[function pointer]";
 
         if(is_entry(ci)) {
           call_stack.push_back("call: " + Z3TraceChecker::remove_stub(name));

--- a/tesla/static/model-checker/ModelChecker.h
+++ b/tesla/static/model-checker/ModelChecker.h
@@ -121,6 +121,8 @@ public:
 
   bool is_safe() const;
 protected: 
+  bool match_arg(const Value* x, const Value* y) const;
+
   bool check_event(const CallInst& CI, const tesla::Expression& expr) const;
   bool check_function(const CallInst& CI, const tesla::FunctionEvent& expr) const;
   bool check_assert(const CallInst& CI, const tesla::AssertionSite& expr) const;

--- a/tesla/static/model-checker/Z3Pass.cpp
+++ b/tesla/static/model-checker/Z3Pass.cpp
@@ -15,7 +15,7 @@ namespace tesla {
 unique_ptr<Manifest> Z3Pass::run(Manifest& man, Module& mod)
 {
   PassManager Passes;
-  Passes.add(createPromoteMemoryToRegisterPass());
+  //Passes.add(createPromoteMemoryToRegisterPass());
   Passes.add(new StubFunctionsPass);
   Passes.run(mod);
 


### PR DESCRIPTION
This sorts out a lot of small issues caused tangentially by LLVM
upgrades - names were no longer being preserved by mem2reg, so it has
been removed. As well, lots of NPEs were coming up in places where a
call target didn't actually exist.