### PR TITLE
Assertions can possibly be checked

### DIFF
--- a/tesla/static/model-checker/ModelChecker.cpp
+++ b/tesla/static/model-checker/ModelChecker.cpp
@@ -34,6 +34,8 @@ Z3TraceChecker::Z3TraceChecker(Function& tf, Module& mod,
   bound_(tf), module_(mod), trace_(TraceFinder::linear_trace(tf)), 
   constraints_(cons), fsm_(fsm)
 {
+  checked_functions_.insert(tesla::INLINE_ASSERTION);
+
   const auto& labels = fsm_.AllLabels();
   for(const auto& expr : labels) {
     if(expr->type() == Expression_Type_FUNCTION) {


### PR DESCRIPTION
This fixes an unsafety issue where a failure caused by an unexpected assertion site event wouldn't be recognised.