### PR TITLE
Try different lit names

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -3,7 +3,10 @@
 import os
 import sys
 
-import lit40 as lit
+try:
+  import lit
+except ImportError:
+  import lit40 as lit
 
 #
 # Basic information about this test suite.


### PR DESCRIPTION
This means that lit can be imported if it is installed as `lit` or `lit40`