### PR TITLE
Fix test failures from CPP output

### DIFF
--- a/scripts/test_support.py
+++ b/scripts/test_support.py
@@ -32,11 +32,8 @@ def ldflags(dirs, libs, extras = []):
 
 def cpp_out():
 	""" How do we specify the output file from our platform's cpp? """
-	cpp_version = run_command('cpp', [ '--version' ]).split('\n')[0]
-
-	# Clang usage: 'cpp in -o out'; GCC usage: 'cpp in out'
-	if 'clang' in cpp_version: return '-o'
-	else: return ''
+        # Clang 4.0 CPP no longer seems to need -o, so this is always empty
+        return ''
 
 
 def find_containing_dir(filename, paths, notfound_msg):


### PR DESCRIPTION
This works on FreeBSD as well.