### PR TITLE
Fix analyser CLI

### DIFF
--- a/tesla/analyser/Tool.cpp
+++ b/tesla/analyser/Tool.cpp
@@ -53,8 +53,7 @@ cl::opt<string> OutputFile(
 
 cl::list<string> SourcePaths(
   cl::Positional,
-  cl::desc("<source0> [... <sourceN>]"),
-  cl::OneOrMore);
+  cl::desc("<source>"));
 
 
 int main(int argc, const char **argv) {


### PR DESCRIPTION
The analyser CLI indicates that it can take multiple source files as input - however, the output file can only be specified once. This PR fixes this ambiguity by restricting the tool to a single source file input at once.