### PR TITLE
Allow for opt tool to be configured

### DIFF
--- a/scripts/tesla
+++ b/scripts/tesla
@@ -22,6 +22,11 @@ fi
 TOOL_NAME="tesla-$1"
 shift
 
+# Use the default opt by default, but allow it to be overridden if necessary
+# (to use the same version of LLVM as the TESLA passes were compiled against)
+OPT=${OPT:-opt}
+echo $OPT
+
 # The instrumenter and static analysis tool are now implemented as opt passes,
 # so instead of calling them as a tool, we pass some arguments through to opt
 if [ "$TOOL_NAME" = "tesla-instrument" ] || [ "$TOOL_NAME" = "tesla-static" ]; then
@@ -39,7 +44,7 @@ if [ "$TOOL_NAME" = "tesla-instrument" ] || [ "$TOOL_NAME" = "tesla-static" ]; t
     LIB="$LIB_NAME"
   fi
 
-  opt -load "$LIB" "-$TOOL_NAME" "$@"
+  $OPT -load "$LIB" "-$TOOL_NAME" "$@"
   exit $?
 fi
 


### PR DESCRIPTION
Let users of the `tesla` script specify what `opt` executable they want to run.

This change is motivated by the way Homebrew installs TESLA - `opt` from AppleClang can't load passes compiled against Homebrew LLVM, so it might be necessary to point the script to the Homebrew `opt` executable.