### PR TITLE
Static analysis pass doesn't ever modify the module it's given

### DIFF
--- a/scripts/tesla
+++ b/scripts/tesla
@@ -25,7 +25,6 @@ shift
 # Use the default opt by default, but allow it to be overridden if necessary
 # (to use the same version of LLVM as the TESLA passes were compiled against)
 OPT=${OPT:-opt}
-echo $OPT
 
 # The instrumenter and static analysis tool are now implemented as opt passes,
 # so instead of calling them as a tool, we pass some arguments through to opt

--- a/tesla/instrumenter/StaticPass.cpp
+++ b/tesla/instrumenter/StaticPass.cpp
@@ -52,6 +52,6 @@ bool StaticPass::runOnModule(Module& M)
 }
 
 char StaticPass::ID = 0;
-static RegisterPass<StaticPass> X("tesla-static", "Optimise TESLA instrumentation statically");
+static RegisterPass<StaticPass> X("tesla-static", "Optimise TESLA instrumentation statically", true, true);
 
 }


### PR DESCRIPTION
This means we register the pass with the appropriate parameters rather than the defaults.